### PR TITLE
Remove extra word from example 3 copy

### DIFF
--- a/_includes/example3-code.html
+++ b/_includes/example3-code.html
@@ -1,6 +1,6 @@
 <h2 id="example3" tabindex="0">Custom flip behavior</h2>
 <p>
-    Try dragging the reference element on the left side, its popper will move on its the bottom edge.
+    Try dragging the reference element on the left side, its popper will move on its bottom edge.
     Then, try to move the reference element on the bottom left corner, it will move on its top edge.
 </p>
 {% highlight javascript %}


### PR DESCRIPTION
**Description**
The extra `the` word makes the text a bit strange (and harder to read too if you're not an advanced or native English speaker), thus, removing it will help the general understanding of the this piece of text/example

**Changes**
- Removal of extra `the` word from copy