### PR TITLE
make onCreate and onUpdate chainable

### DIFF
--- a/src/popper.js
+++ b/src/popper.js
@@ -240,6 +240,7 @@
     Popper.prototype.onCreate = function(callback) {
         // the createCallbacks return as first argument the popper instance
         callback(this);
+        return this;
     };
 
     /**
@@ -251,6 +252,7 @@
      */
     Popper.prototype.onUpdate = function(callback) {
         this.state.updateCallback = callback;
+        return this;
     };
 
     /**

--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -324,4 +324,15 @@ describe('Popper.js', function() {
             done();
         });
     });
+
+    it('uses onCreate and onUpdate chained', function(done) {
+        var reference = appendNewRef(1);
+
+        new TestPopper(reference).onCreate(function(instance) {
+            expect(instance._popper).toBeDefined();
+        }).onUpdate(function(data) {
+            expect(data.offsets.popper.top).toBeApprox(63);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
I've added a test to make sure the feature work...
If someone can understand where the problem is...

It correctly enter inside the `prototype.onUpdate` function, but when it sets `this.state.updateCallback` something goes wrong.
In fact,  when `update` is called, `updateCallback` is `undefined`