### PR TITLE
Fix calculation of popper elements' outerSizes

### DIFF
--- a/src/popper.js
+++ b/src/popper.js
@@ -158,7 +158,7 @@
         // refactoring modifiers' list
         this._options.modifiers = this._options.modifiers.map(function(modifier){
             // remove ignored modifiers
-            if (this._options.modifiersIgnored.indexOf(modifier) >= 0) return;
+            if (this._options.modifiersIgnored.indexOf(modifier) !== -1) return;
 
             // set the x-placement attribute before everything else because it could be used to add margins to the popper
             // margins needs to be calculated to get the correct popper offsets
@@ -167,7 +167,7 @@
             }
 
             // return predefined modifier identified by string or keep the custom one
-	    return this.modifiers[modifier] || modifier;
+            return this.modifiers[modifier] || modifier;
         }.bind(this));
 
         // make sure to apply the popper position before any computation
@@ -931,13 +931,13 @@
         var _display = element.style.display, _visibility = element.style.visibility;
         element.style.display = 'block'; element.style.visibility = 'hidden';
         var calcWidthToForceRepaint = element.offsetWidth;
-        
+
         // original method
         var styles = root.getComputedStyle(element);
         var x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
         var y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);
         var result = { width: element.offsetWidth + y, height: element.offsetHeight + x };
-        
+
         // reset element styles
         element.style.display = _display; element.style.visibility = _visibility;
         return result;

--- a/src/popper.js
+++ b/src/popper.js
@@ -155,17 +155,9 @@
         // with {} we create a new object with the options inside it
         this._options = Object.assign({}, DEFAULTS, options);
 
-        // iterate trough the list of modifiers, the ones defined as strings refers to internal methods of Popper.js
-        // so we return the corresponding method
-        this._options.modifiers = this._options.modifiers.map(function(modifier) {
-            if (typeof modifier === 'string') {
-                if (this._options.modifiersIgnored.indexOf(modifier) !== -1) {
-                    return;
-                }
-                return this.modifiers[modifier];
-            } else {
-                return modifier;
-            }
+        // remove ignored modifiers
+        this._options.modifiers = this._options.modifiers.filter(function(modifier){
+            return this._options.modifiersIgnored.indexOf(modifier) === -1;
         }.bind(this));
 
         // set the x-placement attribute before everything else because it could be used to add margins to the popper
@@ -173,6 +165,16 @@
         if (this._options.modifiers.indexOf('applyStyle') !== -1) {
             this._popper.setAttribute('x-placement', this._options.placement);
         }
+
+        // iterate trough the list of modifiers, the ones defined as strings refers to internal methods of Popper.js
+        // so we return the corresponding method
+        this._options.modifiers = this._options.modifiers.map(function(modifier) {
+            if (typeof modifier === 'string') {
+                return this.modifiers[modifier];
+            } else {
+                return modifier;
+            }
+        }.bind(this));
 
         // make sure to apply the popper position before any computation
         this.state.position = this._getPosition(this._popper, this._reference);
@@ -934,8 +936,7 @@
         // NOTE: 1 DOM access here
         var _display = element.style.display, _visibility = element.style.visibility;
         element.style.display = 'block'; element.style.visibility = 'hidden';
-        // force repaint
-        element.offsetWidth;
+        var calcWidthToForceRepaint = element.offsetWidth;
         
         // original method
         var styles = root.getComputedStyle(element);

--- a/src/popper.js
+++ b/src/popper.js
@@ -155,25 +155,19 @@
         // with {} we create a new object with the options inside it
         this._options = Object.assign({}, DEFAULTS, options);
 
-        // remove ignored modifiers
-        this._options.modifiers = this._options.modifiers.filter(function(modifier){
-            return this._options.modifiersIgnored.indexOf(modifier) === -1;
-        }.bind(this));
+        // refactoring modifiers' list
+        this._options.modifiers = this._options.modifiers.map(function(modifier){
+            // remove ignored modifiers
+            if (this._options.modifiersIgnored.indexOf(modifier) >= 0) return;
 
-        // set the x-placement attribute before everything else because it could be used to add margins to the popper
-        // margins needs to be calculated to get the correct popper offsets
-        if (this._options.modifiers.indexOf('applyStyle') !== -1) {
-            this._popper.setAttribute('x-placement', this._options.placement);
-        }
-
-        // iterate trough the list of modifiers, the ones defined as strings refers to internal methods of Popper.js
-        // so we return the corresponding method
-        this._options.modifiers = this._options.modifiers.map(function(modifier) {
-            if (typeof modifier === 'string') {
-                return this.modifiers[modifier];
-            } else {
-                return modifier;
+            // set the x-placement attribute before everything else because it could be used to add margins to the popper
+            // margins needs to be calculated to get the correct popper offsets
+            if (modifier === 'applyStyle') {
+                this._popper.setAttribute('x-placement', this._options.placement);
             }
+
+            // return predefined modifier identified by string or keep the custom one
+	    return this.modifiers[modifier] || modifier;
         }.bind(this));
 
         // make sure to apply the popper position before any computation

--- a/src/popper.js
+++ b/src/popper.js
@@ -932,11 +932,20 @@
      */
     function getOuterSizes(element) {
         // NOTE: 1 DOM access here
+        var _display = element.style.display, _visibility = element.style.visibility;
+        element.style.display = 'block'; element.style.visibility = 'hidden';
+        // force repaint
+        element.offsetWidth;
+        
+        // original method
         var styles = root.getComputedStyle(element);
         var x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
         var y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);
-
-        return { width: element.offsetWidth + y, height: element.offsetHeight + x };
+        var result = { width: element.offsetWidth + y, height: element.offsetHeight + x };
+        
+        // reset element styles
+        element.style.display = _display; element.style.visibility = _visibility;
+        return result;
     }
 
     /**

--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -356,7 +356,7 @@ describe('Popper.js', function() {
             { contentType: 'node', content: popperContent },
             { placement: 'left', removeOnDestroy: true }
         ).onCreate(function(instance) {
-            expect(instance._popper.getBoundingClientRect().left).toBe(548);
+            expect(instance._popper.getBoundingClientRect().left).toBe(543);
             instance.destroy();
             done();
         });


### PR DESCRIPTION
This pull requests fixes popper.js code in order to correctly calculate outerSize of popper element and its arrows, event if they are set as `display: none`. This will fix the issue #46 .

This codepen is using the new popper.js script and doesnt have the re-positioning bug:
http://codepen.io/rafaelverger/pen/WwPNEd