### PR TITLE
added ability to set custom styles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function(grunt) {
                 },
                 files: [
                     { pattern: 'bower_components/**/*.js', included: false },
-                    { pattern: 'bower_components/requirejs/require.js', included: true },
+                    { pattern: 'node_modules/requirejs/require.js', included: true },
                     { pattern: 'src/**/*.js', included: false },
                     'tests/*.js',
                     'tests/styles/*.css'

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Additionally, it provides an easy way to generate your popper element if you don
 ### Installation
 Popper.js is available on NPM and Bower:
 
-| Source      |                                              |
-|-------------|----------------------------------------------|
-|NPM          | `npm install popper.js --save`               |
-|Bower        | `bower install popper.js --save`             |
-|jsDelivr     | `http://www.jsdelivr.com/projects/popper.js` |
+| Source   |                                              |
+|:---------|:---------------------------------------------|
+| NPM      | `npm install popper.js --save`               |
+| Bower    | `bower install popper.js --save`             |
+| jsDelivr | `http://www.jsdelivr.com/projects/popper.js` |
 
 ### Basic usage
 Create a popper near a button:
@@ -152,8 +152,10 @@ let data = {
   // allows you to know if the `flip` modifier have flipped the placement of the popper
   flipped: Boolean,
   // the node of the arrow (if any)
-  arrowElement: HTMLElement
-  
+  arrowElement: HTMLElement,
+  // any property defined in this object will be applied to the popper element
+  // here you can even override the default styles applied by Popper.js
+  styles: {}
 }
 ```
 

--- a/bower.json
+++ b/bower.json
@@ -18,8 +18,5 @@
     "bower_components",
     "test",
     "tests"
-  ],
-  "devDependencies": {
-    "requirejs": "^2.2.0"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.2",
-    "karma-jasmine": "^0.3.8"
+    "karma-jasmine": "^0.3.8",
+    "requirejs": "^2.2.0"
   }
 }

--- a/src/popper.js
+++ b/src/popper.js
@@ -218,7 +218,7 @@
      * @memberof Popper
      */
     Popper.prototype.update = function() {
-        var data = { instance: this };
+        var data = { instance: this, styles: {} };
 
         // store placement inside the data object, modifiers will be able to edit `placement` if needed
         // and refer to _originalPlacement to know the original value
@@ -621,6 +621,12 @@
             styles.left =left;
             styles.top = top;
         }
+
+        // any property present in `data.styles` will be applied to the popper,
+        // in this way we can make the 3rd party modifiers add custom styles to it
+        // Be aware, modifiers could override the properties defined in the previous
+        // lines of this modifier!
+        Object.assign(styles, data.styles);
 
         setStyle(this._popper, styles);
 

--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -361,4 +361,45 @@ describe('Popper.js', function() {
             done();
         });
     });
+
+    it('creates a popper with a custom modifier that should hide it', function(done) {
+        var reference = appendNewRef(1);
+        var popper    = appendNewPopper(2);
+
+        function hidePopper(data) {
+            data.styles.display = 'none';
+            return data;
+        }
+
+        var options = {
+            modifiers: [hidePopper, 'applyStyle'],
+        };
+
+        new TestPopper(reference, popper, options).onCreate(function(pop) {
+            expect(popper.style.display).toBe('none');
+            pop.destroy();
+            done();
+        });
+    });
+
+
+    it('creates a popper with a custom modifier that set its top to 3px', function(done) {
+        var reference = appendNewRef(1);
+        var popper    = appendNewPopper(2);
+
+        function hidePopper(data) {
+            data.styles.top = '3px';
+            return data;
+        }
+
+        var options = {
+            modifiers: [hidePopper, 'applyStyle'],
+        };
+
+        new TestPopper(reference, popper, options).onCreate(function(pop) {
+            expect(popper.style.top).toBe('3px');
+            pop.destroy();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
This PR allows 3rd party modifiers to hook inside the `applyStyles` modifier.

Thanks to this edit, your custom modifier can now apply custom styling to the popper element defining the CSS properties inside `data.styles`.

Example:

```js
function hidePopperModifier(data) {
  data.styles.display = 'none';
  return data;
}
```

This should help with #52