### PR TITLE
Added support for a reference el that is both fixed and transformed.

### DIFF
--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -203,6 +203,36 @@ describe('Popper.js', function() {
         });
     });
 
+    it('inits a popper near a reference element, both inside a fixed element with CSS transforms, inside a scrolled body', function(done) {
+        var fixed = document.createElement('div');
+        fixed.style.position = 'fixed';
+        fixed.style.margin = '20px';
+        fixed.style.height = '50px';
+        fixed.style.width = '100%';
+        fixed.style.transform = 'translateX(0)'
+        jasmineWrapper.appendChild(fixed);
+
+        var relative = document.createElement('div');
+        relative.style.position = 'relative';
+        relative.style.margin = '20px';
+        relative.style.height = '200vh';
+        jasmineWrapper.appendChild(relative);
+        document.body.scrollTop = 800;
+
+        var ref = appendNewRef(1, 'ref', fixed);
+        var popper = appendNewPopper(2, 'popper', fixed);
+
+        new TestPopper(ref, popper).onCreate(function(pop) {
+            // force redraw
+            window.dispatchEvent(new Event('resize'));
+
+            expect(popper.getBoundingClientRect().top).toBeApprox(83);
+            expect(popper.getBoundingClientRect().left).toBeApprox(33);
+            pop.destroy();
+            done();
+        });
+    });
+
     it('inits a popper near a reference element, both inside a fixed element on bottom of viewport, inside a scrolled body', function(done) {
         var fixed = document.createElement('div');
         fixed.style.position = 'fixed';


### PR DESCRIPTION
This fixes #56.

Similar to how the parent's position is checked, I added a check for any transformations on the parent. If transforms are present, Popper changes the way it calculates offsets. This is necessary because when a parent has a transform applied, the origin of the transform switches to that element instead of the viewport. See the [W3C Spec](http://www.w3.org/TR/css3-2d-transforms/#transform-rendering):

> In the HTML namespace, any value other than none for the transform results in the creation of both a stacking context and a containing block. The object acts as a containing block for fixed positioned descendants.

Since I added the check for `isParentTransformed`, any existing Popper should (in theory) work the same way. I tried to mimic the existing code flow/style as much as possible, but if you have any suggestions I am all ears.

Thanks!