### PR TITLE
fixes issue with shadowRoot and computed styles

### DIFF
--- a/src/utils/getStyleComputedProperty.js
+++ b/src/utils/getStyleComputedProperty.js
@@ -6,6 +6,9 @@
  * @argument {String} property
  */
 export default function getStyleComputedProperty(element, property) {
+    if (element.nodeType !== 1) {
+        return [];
+    }
     // NOTE: 1 DOM access here
     const css = window.getComputedStyle(element, null);
     return css[property];


### PR DESCRIPTION
When a popper's reference element is inside shadowRoot, popper fails.

Codepen:
https://codepen.io/nadiam84/pen/yJQvkB

It happens inside getScrollParent function, when it tries to  up the tree here: `getScrollParent(element.parentNode)`. At some point parentNode of an element inside shadowRoot is going to be shadowRoot itself, and apparently you can't do `getComputedStyle` on it. This PR is fixing this problem.

All tests were green locally btw