### PR TITLE
Using parentNode.removeChild when element.remove is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,6 @@ let data = {
 }
 ```
 
-### Internet Explorer
-Exactly, we are in 2016, and we still talk about workarounds for IE...
-
-If you need the `removeOnDestroy` option in IE 11 and below, please make sure to add this polyfill before Popper.js:
-https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove
-
-
 
 ## Libraries using Popper.js
 

--- a/src/popper.js
+++ b/src/popper.js
@@ -210,11 +210,7 @@
 
         // remove the popper if user explicity asked for the deletion on destroy
         if (this._options.removeOnDestroy) {
-            if (this._popper.remove) {
-                this._popper.remove();
-            } else {
-                this._popper.parentNode.removeChild(this._popper);
-            }
+            this._popper.parentNode.removeChild(this._popper);
         }
         return this;
     };

--- a/src/popper.js
+++ b/src/popper.js
@@ -210,7 +210,11 @@
 
         // remove the popper if user explicity asked for the deletion on destroy
         if (this._options.removeOnDestroy) {
-            this._popper.remove();
+            if (this._popper.remove) {
+                this._popper.remove();
+            } else {
+                this._popper.parentNode.removeChild(this._popper);
+            }
         }
         return this;
     };

--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -335,20 +335,6 @@ describe('Popper.js', function() {
             done();
         });
     });
-
-    it('creates a popper without remove method, then assert it\'s gone after calling destroy', function(done) {
-        var form = document.createElement('form');
-        var reference = appendNewRef(1, 'ref', form);
-        jasmineWrapper.appendChild(form);
-
-        new TestPopper(reference, { parent: form }, { removeOnDestroy: true }).onCreate(function(instance) {
-            expect(instance._popper).toBeDefined();
-	    instance._popper.remove = undefined;
-            instance.destroy();
-            expect(document.contains(instance._popper)).toBeFalsy();
-            done();
-        });
-    });
     
     it('creates a popper with a not empty form as parent, then auto remove it on destroy', function(done) {
         var form = document.createElement('form');

--- a/tests/test-popper.js
+++ b/tests/test-popper.js
@@ -336,6 +336,20 @@ describe('Popper.js', function() {
         });
     });
 
+    it('creates a popper without remove method, then assert it\'s gone after calling destroy', function(done) {
+        var form = document.createElement('form');
+        var reference = appendNewRef(1, 'ref', form);
+        jasmineWrapper.appendChild(form);
+
+        new TestPopper(reference, { parent: form }, { removeOnDestroy: true }).onCreate(function(instance) {
+            expect(instance._popper).toBeDefined();
+	    instance._popper.remove = undefined;
+            instance.destroy();
+            expect(document.contains(instance._popper)).toBeFalsy();
+            done();
+        });
+    });
+    
     it('creates a popper with a not empty form as parent, then auto remove it on destroy', function(done) {
         var form = document.createElement('form');
         var input = document.createElement('input');


### PR DESCRIPTION
This fix `popper.destroy` method on browsers that doesn't support [Element.remove method](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#Browser_compatibility)