### PR TITLE
Fix parent node

### DIFF
--- a/src/utils/getParentNode.js
+++ b/src/utils/getParentNode.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the parentNode or the host of the element
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Element} element
+ * @returns {Element} parent
+ */
+export default function getParentNode(element) {
+    return element.parentNode || element.host;
+}

--- a/src/utils/getScrollParent.js
+++ b/src/utils/getScrollParent.js
@@ -1,5 +1,6 @@
 import getStyleComputedProperty from './getStyleComputedProperty';
 import getParentNode from './getParentNode';
+
 /**
  * Returns the scrolling parent of the given element
  * @method

--- a/src/utils/getScrollParent.js
+++ b/src/utils/getScrollParent.js
@@ -1,5 +1,5 @@
 import getStyleComputedProperty from './getStyleComputedProperty';
-
+import getParentNode from './getParentNode';
 /**
  * Returns the scrolling parent of the given element
  * @method
@@ -27,7 +27,7 @@ export default function getScrollParent(element) {
         // If the detected scrollParent is body, we perform an additional check on its parentNode
         // in this way we'll get body if the browser is Chrome-ish, or documentElement otherwise
         // fixes issue #65
-        return element === window.document.body ? getScrollParent(element.parentNode) : element;
+        return element === window.document.body ? getScrollParent(getParentNode(element)) : element;
     }
-    return element.parentNode ? getScrollParent(element.parentNode) : element;
+    return getParentNode(element) ? getScrollParent(getParentNode(element)) : element;
 }

--- a/src/utils/isFixed.js
+++ b/src/utils/isFixed.js
@@ -1,4 +1,5 @@
 import getStyleComputedProperty from './getStyleComputedProperty';
+import getParentNode from './getParentNode';
 
 /**
  * Check if the given element is fixed or is inside a fixed parent
@@ -15,5 +16,5 @@ export default function isFixed(element) {
     if (getStyleComputedProperty(element, 'position') === 'fixed') {
         return true;
     }
-    return element.parentNode ? isFixed(element.parentNode) : element;
+    return getParentNode(element) ? isFixed(getParentNode(element)) : element;
 }

--- a/src/utils/isTransformed.js
+++ b/src/utils/isTransformed.js
@@ -1,4 +1,5 @@
 import getStyleComputedProperty from './getStyleComputedProperty';
+import getParentNode from './getParentNode';
 
 /**
  * Check if the given element has transforms applied to itself or a parent
@@ -14,5 +15,5 @@ export default function isTransformed(element) {
   if (getStyleComputedProperty(element, 'transform') !== 'none') {
       return true;
   }
-  return element.parentNode ? isTransformed(element.parentNode) : element;
+  return getParentNode(element) ? isTransformed(getParentNode(element)) : element;
 }


### PR DESCRIPTION
When one of those functions (isFixed, isTransformed, getScrollParent) is trying to get the parent of the element it also should check for the `host` element. Because if the element is inside the shadowRoot it woudn't step outside of it just using `parentNode`, since the shadowRoot doesn't have any parents.