### PR TITLE
Avoid initial Flash Of Unstyled Content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,7 +145,8 @@ module.exports = function Gruntfile(grunt) {
                 },
                 files: [
                     'tests/styles/*.css',
-                    'tests/functional/*.js'
+                    'tests/functional/*.js',
+                    'tests/unit/*.js',
                 ],
                 sauceLabs: {
                     testName: 'Popper.js',

--- a/src/popper.js
+++ b/src/popper.js
@@ -316,7 +316,7 @@ export default class Popper {
         this.popper.style.position = '';
         this.popper.style.top = '';
         this.popper.style[getSupportedPropertyName('transform')] = '';
-        this.state = removeEventListeners(this.reference, this.state, this.options);
+        this.state = removeEventListeners(this.reference, this.state);
 
         // remove the popper if user explicity asked for the deletion on destroy
         // do not use `remove` because IE11 doesn't support it

--- a/src/popper.js
+++ b/src/popper.js
@@ -4,6 +4,7 @@ import './polyfills/requestAnimationFrame';
 
 // Utils
 import Utils from './utils/index';
+import debounce from './utils/debounce';
 import setStyle from './utils/setStyle';
 import isTransformed from './utils/isTransformed';
 import getSupportedPropertyName from './utils/getSupportedPropertyName';
@@ -146,9 +147,15 @@ var DEFAULTS = {
  */
 export default class Popper {
     constructor(reference, popper, options = {}) {
+        // make update() debounced, so that it only runs at most once-per-tick
+        this.update = debounce(this.update.bind(this));
+        // create a throttled version of update() that is scheduled based on UI updates
+        this.scheduleUpdate = () => requestAnimationFrame(this.update);
+
         // init state
         this.state = {
-            isDestroyed: false
+            isDestroyed: false,
+            isCreated: false,
         };
 
         // get reference and popper elements (allow jQuery wrappers)
@@ -200,10 +207,10 @@ export default class Popper {
         this.state.isParentTransformed = isTransformed(this.popper.parentNode);
 
         // fire the first update to position the popper in the right place
-        this.update(true);
+        this.update();
 
         // setup event listeners, they will take care of update the position in specific situations
-        setupEventListeners(this.reference, this.options, this.state, () => this.update());
+        setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
 
         // make it chainable
         return this;
@@ -216,53 +223,42 @@ export default class Popper {
     /**
      * Updates the position of the popper, computing the new offsets and applying the new style
      * @method
-     * @param {Boolean} isFirstCall
-     *      When true, the onCreate callback is called, otherwise it calls the onUpdate callback
      * @memberof Popper
      */
-    update(isFirstCall) {
+    update() {
         var data = { instance: this, styles: {} };
 
         // make sure to apply the popper position before any computation
         this.state.position = getPosition(this.popper, this.reference);
         setStyle(this.popper, { position: this.state.position});
 
-        // to avoid useless computations we throttle the popper position refresh to 60fps
-        window.requestAnimationFrame(() => {
-            // if popper is destroyed, don't perform any further update
-            if (this.state.isDestroyed) { return; }
+        // if popper is destroyed, don't perform any further update
+        if (this.state.isDestroyed) { return; }
 
-            const now = window.performance.now();
-            if (now - this.state.lastFrame <= 16) {
-                // this update fired to early! drop it
-                // but schedule a new one that will be ran at the end of the updates
-                // chain to make sure everything is proper updated
-                return this.update();
+        // store placement inside the data object, modifiers will be able to edit `placement` if needed
+        // and refer to originalPlacement to know the original value
+        data.placement = this.options.placement;
+        data.originalPlacement = this.options.placement;
+
+        // compute the popper and reference offsets and put them inside data.offsets
+        data.offsets = getOffsets(this.state, this.popper, this.reference, data.placement);
+
+        // get boundaries
+        data.boundaries = getBoundaries(this.popper, data, this.options.boundariesPadding, this.options.boundariesElement);
+
+        // run the modifiers
+        data = runModifiers(this.modifiers, this.options, data);
+
+        // the first `update` will call `onCreate` callback
+        // the other ones will call `onUpdate` callback
+        if (!this.state.isCreated) {
+            this.state.isCreated = true;
+            if (isFunction(this.state.createCallback)) {
+                this.state.createCallback(data);
             }
-            this.state.lastFrame = now;
-
-            // store placement inside the data object, modifiers will be able to edit `placement` if needed
-            // and refer to originalPlacement to know the original value
-            data.placement = this.options.placement;
-            data.originalPlacement = this.options.placement;
-
-            // compute the popper and reference offsets and put them inside data.offsets
-            data.offsets = getOffsets(this.state, this.popper, this.reference, data.placement);
-
-            // get boundaries
-            data.boundaries = getBoundaries(this.popper, data, this.options.boundariesPadding, this.options.boundariesElement);
-
-            // run the modifiers
-            data = runModifiers(this.modifiers, this.options, data);
-
-            // the first `update` will call `onCreate` callback
-            // the other ones will call `onUpdate` callback
-            if (isFirstCall && isFunction(this.state.createCalback)) {
-                this.state.createCalback(data);
-            } else if (!isFirstCall && isFunction(this.state.updateCallback)) {
-                this.state.updateCallback(data);
-            }
-        });
+        } else if (isFunction(this.state.updateCallback)) {
+            this.state.updateCallback(data);
+        }
     }
 
     /**
@@ -273,7 +269,7 @@ export default class Popper {
      */
     onCreate(callback) {
         // the createCallbacks return as first argument the popper instance
-        this.state.createCalback = callback;
+        this.state.createCallback = callback;
         return this;
     }
 

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,52 @@
+const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
+let timeoutDuration = 0;
+for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {
+  if (navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
+    timeoutDuration = 1;
+    break;
+  }
+}
+
+function microtaskDebounce(fn) {
+  let called = false;
+  let i = 0;
+  const elem = document.createElement('span');
+  const observer = new MutationObserver(() => {
+    fn();
+    called = false;
+  });
+
+  observer.observe(elem, { childList: true });
+
+  return () => {
+    if (!called) {
+      called = true;
+      elem.textContent = `${i}`;
+      i += 1;
+    }
+  };
+}
+
+function taskDebounce(fn) {
+  let called = false;
+  return () => {
+    if (!called) {
+      called = true;
+      setTimeout(() => {
+        called = false;
+        fn();
+      }, timeoutDuration);
+    }
+  };
+}
+
+/**
+ * Create a debounced version of a method, that's asynchronously deferred
+ * but called in the minimum time possible.
+ *
+ * @method
+ * @memberof Popper.Utils
+ * @argument {Function} fn
+ * @returns {Function}
+ */
+export default window.MutationObserver ? microtaskDebounce : taskDebounce;

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -57,7 +57,6 @@ const supportsNativeMutationObserver = isNative(window.MutationObserver);
  * but called in the minimum time possible.
  *
  * @method
- * @memberof Popper.Utils
  * @argument {Function} fn
  * @returns {Function}
  */

--- a/src/utils/isNative.js
+++ b/src/utils/isNative.js
@@ -1,0 +1,11 @@
+const nativeHints = [
+    'native code',
+    '[object MutationObserverConstructor]' // for mobile safari iOS 9.0
+];
+
+/**
+ * Determine if a function is implemented natively (as opposed to a polyfill).
+ * @argument {Function | undefined} fn the function to check
+ * @returns {boolean}
+ */
+export default fn => nativeHints.some(hint => (fn || '').toString().indexOf(hint) > -1);

--- a/src/utils/removeEventListeners.js
+++ b/src/utils/removeEventListeners.js
@@ -1,12 +1,10 @@
-import getScrollParent from './getScrollParent';
-
 /**
  * Remove event listeners used to update the popper position
  * @method
  * @memberof Popper.Utils
  * @private
  */
-export default function removeEventListeners(reference, state, options) {
+export default function removeEventListeners(reference, state) {
     // NOTE: 1 DOM access here
     window.removeEventListener('resize', state.updateBound);
     if (state.scrollElement) {

--- a/src/utils/removeEventListeners.js
+++ b/src/utils/removeEventListeners.js
@@ -9,14 +9,10 @@ import getScrollParent from './getScrollParent';
 export default function removeEventListeners(reference, state, options) {
     // NOTE: 1 DOM access here
     window.removeEventListener('resize', state.updateBound);
-    if (options.boundariesElement !== 'window') {
-        let target = getScrollParent(reference);
-        // here it could be both `body` or `documentElement` thanks to Firefox, we then check both
-        if (target === window.document.body || target === window.document.documentElement) {
-            target = window;
-        }
-        target.removeEventListener('scroll', state.updateBound);
+    if (state.scrollElement) {
+        state.scrollElement.removeEventListener('scroll', state.updateBound);
     }
     state.updateBound = null;
+    state.scrollElement = null;
     return state;
 }

--- a/src/utils/setupEventListeners.js
+++ b/src/utils/setupEventListeners.js
@@ -18,5 +18,6 @@ export default function setupEventListeners(reference, options, state, updateBou
             target = window;
         }
         target.addEventListener('scroll', state.updateBound, { passive: true });
+        state.scrollElement = target;
     }
 }

--- a/tests/functional/core.js
+++ b/tests/functional/core.js
@@ -254,14 +254,18 @@ describe('[core]', () => {
             modifiers: {
                 applyStyle: { enabled: false }
             }
-        }).onUpdate((data) => {
+        })
+        .onCreate(() => {
+            setTimeout(() => {
+                pop.update();
+            });
+        })
+        .onUpdate((data) => {
             expect(data.offsets.popper.top).toBeApprox(46);
             jasmineWrapper.removeChild(data.instance.popper);
             data.instance.destroy();
             done();
         });
-
-        pop.update();
     });
 
     it('inits a popper with an empty form as parent, then auto remove it on destroy', (done) => {

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -21,7 +21,7 @@ describe('[lifecycle]', () => {
         it('does not add a scroll event listener to window when boundariesElement is window', () => {
             spyOn(window, 'addEventListener');
 
-            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { boundariesElement: 'window' });
+            makePopper(makeConnectedElement(), makeConnectedElement(), { boundariesElement: 'window' });
 
             expect(window.addEventListener.calls.count()).toEqual(1);
             expect(window.addEventListener.calls.argsFor(0)[0]).not.toEqual('scroll');

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -1,0 +1,113 @@
+import Popper from '../../src/popper';
+import makePopperFactory from '../utils/makePopperFactory';
+import makeConnectedElement from '../utils/makeConnectedElement';
+import makeConnectedScrollElement from '../utils/makeConnectedScrollElement';
+import makeElement from '../utils/makeElement';
+import '../setup';
+
+
+describe('[lifecycle]', () => {
+    const makePopper = makePopperFactory();
+
+    describe('on creation', () => {
+        it('adds a resize event listener', () => {
+            spyOn(window, 'addEventListener');
+
+            const { state } = makePopper(makeConnectedElement(), makeConnectedElement());
+
+            expect(window.addEventListener.calls.argsFor(0)).toEqual(['resize', state.updateBound, { passive: true }]);
+        });
+
+        it('does not add a scroll event listener to window when boundariesElement is window', () => {
+            spyOn(window, 'addEventListener');
+
+            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { boundariesElement: 'window' });
+
+            expect(window.addEventListener.calls.count()).toEqual(1);
+            expect(window.addEventListener.calls.argsFor(0)[0]).not.toEqual('scroll');
+        });
+
+        it('adds a scroll event listener to window when boundariesElement is viewport', () => {
+            spyOn(window, 'addEventListener');
+
+            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { boundariesElement: 'viewport' });
+
+            expect(window.addEventListener.calls.argsFor(1)).toEqual(['scroll', state.updateBound, { passive: true }]);
+        });
+
+        it('adds a scroll event listener to the closest scroll ancestor of reference when boundariesElement is an element', () => {
+            const boundariesElement = makeConnectedElement();
+            const scrollAncestor = document.createElement('div');
+            const reference = document.createElement('div');
+            const popper = document.createElement('div');
+
+            boundariesElement.appendChild(scrollAncestor);
+            scrollAncestor.appendChild(reference);
+            scrollAncestor.appendChild(popper);
+
+            scrollAncestor.style.overflow = 'scroll';
+
+            spyOn(scrollAncestor, 'addEventListener');
+            const { state } = makePopper(reference, popper, { boundariesElement: boundariesElement });
+
+            expect(scrollAncestor.addEventListener.calls.allArgs()).toEqual([['scroll', state.updateBound, { passive: true }]]);
+        });
+    });
+
+    describe('on destroy', () => {
+        it('removes the resize event listener from window', () => {
+            spyOn(window, 'removeEventListener');
+
+            const instance = new Popper(makeConnectedElement(), makeConnectedElement());
+            const { updateBound } = instance.state;
+            instance.destroy()
+
+            expect(window.removeEventListener.calls.argsFor(0)).toEqual(['resize', updateBound]);
+        });
+
+        it('removes the scroll event listener from window', () => {
+            spyOn(window, 'removeEventListener');
+
+            const instance = new Popper(makeConnectedElement(), makeConnectedElement());
+            const { updateBound } = instance.state;
+            instance.destroy()
+
+            expect(window.removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
+        });
+
+        describe('when boundariesElement is not `window` and the scroll parent is not `window`', () => {
+            it('removes the scroll event listener from the scroll parent', () => {
+                const boundariesElement = makeConnectedScrollElement();
+                const reference = boundariesElement.appendChild(makeElement());
+                const popper = boundariesElement.appendChild(makeElement());
+
+                spyOn(boundariesElement, 'removeEventListener');
+
+                const instance = new Popper(reference, popper, { boundariesElement: boundariesElement });
+                const { updateBound } = instance.state;
+                instance.destroy()
+
+                expect(boundariesElement.removeEventListener.calls.allArgs()).toEqual([['scroll', updateBound]]);
+            });
+
+            describe('when the reference is disconnected from the DOM', () => {
+                it('removes the scroll event listener from the scroll parent when the reference is disconnected from the DOM', () => {
+                    const boundariesElement = makeConnectedScrollElement();
+                    const reference = boundariesElement.appendChild(makeElement());
+                    const popper = boundariesElement.appendChild(makeElement());
+
+                    spyOn(boundariesElement, 'removeEventListener');
+
+                    const instance = new Popper(reference, popper, { boundariesElement: boundariesElement });
+                    const { updateBound } = instance.state;
+
+                    boundariesElement.removeChild(reference);
+                    instance.destroy()
+
+                    expect(boundariesElement.removeEventListener.calls.allArgs()).toEqual([['scroll', updateBound]]);
+                });
+            })
+        });
+    });
+
+});

--- a/tests/functional/rendering.js
+++ b/tests/functional/rendering.js
@@ -1,0 +1,47 @@
+import Popper from '../../src/popper';
+import '../setup';
+
+const jasmineWrapper = document.getElementById('jasmineWrapper');
+
+describe('[rendering]', () => {
+    const makePopper = makePopperFactory();
+
+    it('renders to the DOM before the first paint', (done) => {
+        const spy = jasmine.createSpy('paint watcher');
+        requestAnimationFrame(spy);
+
+        const instance = makePopper(makeElement(), makeElement());
+
+        instance.onCreate(() => {
+            expect(spy).not.toHaveBeenCalled();
+            done();
+        });
+    });
+
+    function makeElement() {
+        const div = document.createElement('div');
+        return jasmineWrapper.appendChild(div);
+    }
+});
+
+
+/**
+ * Create a factory function that produces auto-cleanup popper instances.
+ *
+ * This function must be called in the context of a `describe`, as it utilises
+ * the `afterEach` API to schedule cleanup.
+ */
+function makePopperFactory() {
+    let poppers = [];
+
+    afterEach(() => {
+        poppers.forEach((instance) => instance.destroy());
+        poppers = [];
+    });
+
+    return function factory(...args) {
+        const popper = new Popper(...args);
+        poppers.push(popper);
+        return popper;
+    };
+}

--- a/tests/functional/rendering.js
+++ b/tests/functional/rendering.js
@@ -1,7 +1,7 @@
-import Popper from '../../src/popper';
+import makePopperFactory from '../utils/makePopperFactory';
+import makeConnectedElement from '../utils/makeConnectedElement';
 import '../setup';
 
-const jasmineWrapper = document.getElementById('jasmineWrapper');
 
 describe('[rendering]', () => {
     const makePopper = makePopperFactory();
@@ -10,38 +10,11 @@ describe('[rendering]', () => {
         const spy = jasmine.createSpy('paint watcher');
         requestAnimationFrame(spy);
 
-        const instance = makePopper(makeElement(), makeElement());
+        const instance = makePopper(makeConnectedElement(), makeConnectedElement());
 
         instance.onCreate(() => {
             expect(spy).not.toHaveBeenCalled();
             done();
         });
     });
-
-    function makeElement() {
-        const div = document.createElement('div');
-        return jasmineWrapper.appendChild(div);
-    }
 });
-
-
-/**
- * Create a factory function that produces auto-cleanup popper instances.
- *
- * This function must be called in the context of a `describe`, as it utilises
- * the `afterEach` API to schedule cleanup.
- */
-function makePopperFactory() {
-    let poppers = [];
-
-    afterEach(() => {
-        poppers.forEach((instance) => instance.destroy());
-        poppers = [];
-    });
-
-    return function factory(...args) {
-        const popper = new Popper(...args);
-        poppers.push(popper);
-        return popper;
-    };
-}

--- a/tests/unit/debounce.js
+++ b/tests/unit/debounce.js
@@ -1,0 +1,15 @@
+import debounce from '../../src/utils/debounce';
+
+describe('utils/debounce', () => {
+  it('should be called only once', (done) => {
+    let i = 0;
+    const debounced = debounce(() => (i++));
+    debounced();
+    debounced();
+    debounced();
+    setTimeout(() => {
+      expect(i).toBe(1, 'debounce is called only once');
+      done();
+    }, 1);
+  });
+});

--- a/tests/unit/isNative.js
+++ b/tests/unit/isNative.js
@@ -1,0 +1,18 @@
+import isNative from '../../src/utils/isNative';
+
+describe('utils/isNative', () => {
+    it('should return true for Chrome native MutationObserver', () => {
+        const fn = { toString: () => 'function MutationObserver() { [native code] }' };
+        expect(isNative(fn)).toBe(true);
+    });
+
+    it('should return true for Safari native MutationObserver', () => {
+        const fn = { toString: () => '[object MutationObserverConstructor]' };
+        expect(isNative(fn)).toBe(true);
+    });
+
+    it('should return false for a non native function', () => {
+        const fn = () => null;
+        expect(isNative(fn)).toBe(false);
+    });
+});

--- a/tests/utils/makeConnectedElement.js
+++ b/tests/utils/makeConnectedElement.js
@@ -1,0 +1,9 @@
+import makeElement from './makeElement';
+
+/**
+ * Create an element that's connected to the DOM.
+ */
+export default function makeConnectedElement() {
+    const jasmineWrapper = document.getElementById('jasmineWrapper');
+    return jasmineWrapper.appendChild(makeElement());
+}

--- a/tests/utils/makeConnectedScrollElement.js
+++ b/tests/utils/makeConnectedScrollElement.js
@@ -1,0 +1,10 @@
+import makeConnectedElement from './makeConnectedElement';
+
+/**
+ * Create a scrollable element that's connected to the DOM.
+ */
+export default function makeConnectedScrollElement() {
+    const elem = makeConnectedElement();
+    elem.style.overflow = 'scroll';
+    return elem;
+}

--- a/tests/utils/makeElement.js
+++ b/tests/utils/makeElement.js
@@ -1,0 +1,6 @@
+/**
+ * Create an element.
+ */
+export default function makeElement() {
+    return document.createElement('div');
+}

--- a/tests/utils/makePopperFactory.js
+++ b/tests/utils/makePopperFactory.js
@@ -1,0 +1,22 @@
+import Popper from '../../src/popper';
+
+/**
+ * Create a factory function that produces auto-cleanup popper instances.
+ *
+ * This function must be called in the context of a `describe`, as it utilises
+ * the `afterEach` API to schedule cleanup.
+ */
+export default function makePopperFactory() {
+    let poppers = [];
+
+    afterEach(() => {
+        poppers.forEach((instance) => instance.destroy());
+        poppers = [];
+    });
+
+    return function factory(...args) {
+        const popper = new Popper(...args);
+        poppers.push(popper);
+        return popper;
+    };
+}


### PR DESCRIPTION
This change ensures that popper is rendered prior to the first frame being painted. It fixes a race condition where the first call to `requestAnimationFrame` is "too late" and is not scheduled before the browser paints the page.
