### PR TITLE
Add enable/disable method

### DIFF
--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -188,7 +188,6 @@ export default class Popper {
         this.state = {
             isDestroyed: false,
             isCreated: false,
-            isEnabled: this.options.eventsEnabled,
         };
 
         // get reference and popper elements (allow jQuery wrappers)
@@ -242,10 +241,13 @@ export default class Popper {
         // fire the first update to position the popper in the right place
         this.update();
 
-        if (this.state.isEnabled) {
+        const eventsEnabled = this.options.eventsEnabled;
+        if (eventsEnabled) {
             // setup event listeners, they will take care of update the position in specific situations
-            this.enable(true);
+            this.enable();
         }
+
+        this.state.isEnabled = eventsEnabled;
     }
 
     //
@@ -341,8 +343,8 @@ export default class Popper {
      * @method
      * @memberof Popper
      */
-    enable(initial) {
-        if (!this.state.isEnabled || initial) {
+    enable() {
+        if (!this.state.isEnabled) {
             setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
             this.state.isEnabled = true;
         }

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -24,8 +24,8 @@ const DEFAULTS = {
     // placement of the popper
     placement: 'bottom',
 
-    // is initially enabled or not
-    enabled: true,
+    // whether events (resize, scroll) are initially enabled
+    eventsEnabled: true,
 
     /**
      * Callback called when the popper is created.
@@ -123,8 +123,8 @@ const DEFAULTS = {
  *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),
  *      left(-start, -end)`
  *
- * @param {Boolean} options.enabled=true
- *      Whether popper is initially enabled or not
+ * @param {Boolean} options.eventsEnabled=true
+ *      Whether events (resize, scroll) are initially enabled
  * @param {Boolean} options.gpuAcceleration=true
  *      When this property is set to true, the popper position will be applied using CSS3 translate3d, allowing the
  *      browser to use the GPU to accelerate the rendering.
@@ -188,7 +188,7 @@ export default class Popper {
         this.state = {
             isDestroyed: false,
             isCreated: false,
-            isEnabled: this.options.enabled,
+            isEnabled: this.options.eventsEnabled,
         };
 
         // get reference and popper elements (allow jQuery wrappers)
@@ -244,7 +244,7 @@ export default class Popper {
 
         if (this.state.isEnabled) {
             // setup event listeners, they will take care of update the position in specific situations
-           setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
+            this.enable(true);
         }
     }
 
@@ -336,19 +336,22 @@ export default class Popper {
     }
 
     /**
-     * Enables popper
+     * Enables popper - it will add resize/scroll events and start
+     * recalculating position of the popper element when they are triggered
      * @method
      * @memberof Popper
      */
-    enable() {
-        if (!this.state.isEnabled) {
+    enable(initial) {
+        if (!this.state.isEnabled || initial) {
             setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
             this.state.isEnabled = true;
         }
     }
 
     /**
-     * Disables popper
+     * Disables popper - it will remove resize/scroll events and won't recalculate
+     * popper position when they are triggered. It also won't trigger onUpdate callback anymore,
+     * unless you call 'update' method manually.
      * @method
      * @memberof Popper
      */

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -24,6 +24,9 @@ const DEFAULTS = {
     // placement of the popper
     placement: 'bottom',
 
+    // is initially enabled or not
+    enabled: true,
+
     /**
      * Callback called when the popper is created.
      * By default, is set to no-op.
@@ -120,6 +123,8 @@ const DEFAULTS = {
  *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),
  *      left(-start, -end)`
  *
+ * @param {Boolean} options.enabled=true
+ *      Whether popper is initially enabled or not
  * @param {Boolean} options.gpuAcceleration=true
  *      When this property is set to true, the popper position will be applied using CSS3 translate3d, allowing the
  *      browser to use the GPU to accelerate the rendering.
@@ -176,18 +181,19 @@ export default class Popper {
         // make update() debounced, so that it only runs at most once-per-tick
         this.update = debounce(this.update.bind(this));
 
+        // with {} we create a new object with the options inside it
+        this.options = {...Popper.Defaults, ...options};
+
         // init state
         this.state = {
             isDestroyed: false,
             isCreated: false,
+            isEnabled: this.options.enabled,
         };
 
         // get reference and popper elements (allow jQuery wrappers)
         this.reference = reference.jquery ? reference[0] : reference;
         this.popper = popper.jquery ? popper[0] : popper;
-
-        // with {} we create a new object with the options inside it
-        this.options = {...Popper.Defaults, ...options};
 
         // refactoring modifiers' list (Object => Array)
         this.modifiers = Object.keys(Popper.Defaults.modifiers)
@@ -236,8 +242,10 @@ export default class Popper {
         // fire the first update to position the popper in the right place
         this.update();
 
-        // setup event listeners, they will take care of update the position in specific situations
-        setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
+        if (this.state.isEnabled) {
+            // setup event listeners, they will take care of update the position in specific situations
+           setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
+        }
     }
 
     //
@@ -317,8 +325,7 @@ export default class Popper {
             this.popper.style[getSupportedPropertyName('transform')] = '';
         }
 
-        cancelAnimationFrame(this.scheduledUpdate);
-        this.state = removeEventListeners(this.reference, this.state);
+        this.disable();
 
         // remove the popper if user explicity asked for the deletion on destroy
         // do not use `remove` because IE11 doesn't support it
@@ -326,6 +333,31 @@ export default class Popper {
             this.popper.parentNode.removeChild(this.popper);
         }
         return this;
+    }
+
+    /**
+     * Enables popper
+     * @method
+     * @memberof Popper
+     */
+    enable() {
+        if (!this.state.isEnabled) {
+            setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
+            this.state.isEnabled = true;
+        }
+    }
+
+    /**
+     * Disables popper
+     * @method
+     * @memberof Popper
+     */
+    disable() {
+        if (this.state.isEnabled) {
+            cancelAnimationFrame(this.scheduledUpdate);
+            this.state = removeEventListeners(this.reference, this.state);
+            this.state.isEnabled = false;
+        }
     }
 
     /**

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -244,10 +244,10 @@ export default class Popper {
         const eventsEnabled = this.options.eventsEnabled;
         if (eventsEnabled) {
             // setup event listeners, they will take care of update the position in specific situations
-            this.enable();
+            this.enableEventListeners();
         }
 
-        this.state.isEnabled = eventsEnabled;
+        this.state.eventsEnabled = eventsEnabled;
     }
 
     //
@@ -327,7 +327,7 @@ export default class Popper {
             this.popper.style[getSupportedPropertyName('transform')] = '';
         }
 
-        this.disable();
+        this.disableEventListeners();
 
         // remove the popper if user explicity asked for the deletion on destroy
         // do not use `remove` because IE11 doesn't support it
@@ -338,30 +338,30 @@ export default class Popper {
     }
 
     /**
-     * Enables popper - it will add resize/scroll events and start
-     * recalculating position of the popper element when they are triggered
+     * it will add resize/scroll events and start recalculating
+     * position of the popper element when they are triggered
      * @method
      * @memberof Popper
      */
-    enable() {
-        if (!this.state.isEnabled) {
+    enableEventListeners() {
+        if (!this.state.eventsEnabled) {
             setupEventListeners(this.reference, this.options, this.state, this.scheduleUpdate);
-            this.state.isEnabled = true;
+            this.state.eventsEnabled = true;
         }
     }
 
     /**
-     * Disables popper - it will remove resize/scroll events and won't recalculate
+     * it will remove resize/scroll events and won't recalculate
      * popper position when they are triggered. It also won't trigger onUpdate callback anymore,
      * unless you call 'update' method manually.
      * @method
      * @memberof Popper
      */
-    disable() {
-        if (this.state.isEnabled) {
+    disableEventListeners() {
+        if (this.state.eventsEnabled) {
             cancelAnimationFrame(this.scheduledUpdate);
             this.state = removeEventListeners(this.reference, this.state);
-            this.state.isEnabled = false;
+            this.state.eventsEnabled = false;
         }
     }
 

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -44,8 +44,8 @@ describe('[lifecycle]', () => {
             expect(scrollAncestor.addEventListener.calls.allArgs()).toEqual([['scroll', state.updateBound, { passive: true }]]);
         });
 
-        it('should not add resize/scroll event if enabled option is set to false', () => {
-            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { enabled: false });
+        it('should not add resize/scroll event if eventsEnabled option is set to false', () => {
+            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { eventsEnabled: false });
 
             expect(state.isEnabled).toBe(false);
             expect(state.updateBound).toBeUndefined();
@@ -169,24 +169,29 @@ describe('[lifecycle]', () => {
         });
     });
 
-    it('methods: enable/disable', () => {
-        const removeEventListener = spyOn(window, 'removeEventListener');
-        const instance = makePopper(makeConnectedElement(), makeConnectedElement());
-        const { updateBound } = instance.state;
+    describe('methods: enable/disable', () => {
+        it('enable', () => {
+            spyOn(window, 'addEventListener');
+            const instance = makePopper(makeConnectedElement(), makeConnectedElement(), { eventsEnabled: false });
 
-        // disable
-        instance.disable();
-        expect(removeEventListener.calls.argsFor(0)).toEqual(['resize', updateBound]);
-        expect(removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
-        expect(instance.state.isEnabled).toBe(false);
-        expect(instance.state.updateBound).toBe(null);
-        expect(instance.state.scrollElement).toBe(null);
+            instance.enable();
+            expect(window.addEventListener.calls.count()).toEqual(2);
+            expect(window.addEventListener.calls.argsFor(0)).toEqual(['resize', instance.state.updateBound, { passive: true }]);
+            expect(window.addEventListener.calls.argsFor(1)).toEqual(['scroll', instance.state.updateBound, { passive: true }]);
+            expect(instance.state.isEnabled).toBe(true);
+        });
 
-        // enable
-        const addEventListener = spyOn(window, 'addEventListener');
-        instance.enable();
-        expect(addEventListener.calls.argsFor(0)).toEqual(['resize', instance.state.updateBound, { passive: true }]);
-        expect(addEventListener.calls.argsFor(1)).toEqual(['scroll', instance.state.updateBound, { passive: true }]);
-        expect(instance.state.isEnabled).toBe(true);
+        it('disable', () => {
+            spyOn(window, 'removeEventListener');
+            const instance = makePopper(makeConnectedElement(), makeConnectedElement());
+            const { updateBound } = instance.state;
+
+            instance.disable();
+            expect(window.removeEventListener.calls.argsFor(0)).toEqual(['resize', updateBound]);
+            expect(window.removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
+            expect(instance.state.isEnabled).toBe(false);
+            expect(instance.state.updateBound).toBe(null);
+            expect(instance.state.scrollElement).toBe(null);
+        });
     });
 });

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -49,7 +49,7 @@ describe('[lifecycle]', () => {
 
             expect(state.isEnabled).toBe(false);
             expect(state.updateBound).toBeUndefined();
-            expect(state.target).toBeUndefined();
+            expect(state.scrollElement).toBeUndefined();
         });
     });
 
@@ -172,7 +172,7 @@ describe('[lifecycle]', () => {
     it('methods: enable/disable', () => {
         const removeEventListener = spyOn(window, 'removeEventListener');
         const instance = makePopper(makeConnectedElement(), makeConnectedElement());
-        let { updateBound } = instance.state;
+        const { updateBound } = instance.state;
 
         // disable
         instance.disable();
@@ -180,6 +180,7 @@ describe('[lifecycle]', () => {
         expect(removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
         expect(instance.state.isEnabled).toBe(false);
         expect(instance.state.updateBound).toBe(null);
+        expect(instance.state.scrollElement).toBe(null);
 
         // enable
         const addEventListener = spyOn(window, 'addEventListener');

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -47,7 +47,7 @@ describe('[lifecycle]', () => {
         it('should not add resize/scroll event if eventsEnabled option is set to false', () => {
             const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { eventsEnabled: false });
 
-            expect(state.isEnabled).toBe(false);
+            expect(state.eventsEnabled).toBe(false);
             expect(state.updateBound).toBeUndefined();
             expect(state.scrollElement).toBeUndefined();
         });
@@ -169,27 +169,27 @@ describe('[lifecycle]', () => {
         });
     });
 
-    describe('methods: enable/disable', () => {
-        it('enable', () => {
+    describe('methods: enableEventListeners/disableEventListeners', () => {
+        it('enableEventListeners', () => {
             spyOn(window, 'addEventListener');
             const instance = makePopper(makeConnectedElement(), makeConnectedElement(), { eventsEnabled: false });
 
-            instance.enable();
+            instance.enableEventListeners();
             expect(window.addEventListener.calls.count()).toEqual(2);
             expect(window.addEventListener.calls.argsFor(0)).toEqual(['resize', instance.state.updateBound, { passive: true }]);
             expect(window.addEventListener.calls.argsFor(1)).toEqual(['scroll', instance.state.updateBound, { passive: true }]);
-            expect(instance.state.isEnabled).toBe(true);
+            expect(instance.state.eventsEnabled).toBe(true);
         });
 
-        it('disable', () => {
+        it('disableEventListeners', () => {
             spyOn(window, 'removeEventListener');
             const instance = makePopper(makeConnectedElement(), makeConnectedElement());
             const { updateBound } = instance.state;
 
-            instance.disable();
+            instance.disableEventListeners();
             expect(window.removeEventListener.calls.argsFor(0)).toEqual(['resize', updateBound]);
             expect(window.removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
-            expect(instance.state.isEnabled).toBe(false);
+            expect(instance.state.eventsEnabled).toBe(false);
             expect(instance.state.updateBound).toBe(null);
             expect(instance.state.scrollElement).toBe(null);
         });

--- a/tests/functional/lifecycle.js
+++ b/tests/functional/lifecycle.js
@@ -43,6 +43,14 @@ describe('[lifecycle]', () => {
 
             expect(scrollAncestor.addEventListener.calls.allArgs()).toEqual([['scroll', state.updateBound, { passive: true }]]);
         });
+
+        it('should not add resize/scroll event if enabled option is set to false', () => {
+            const { state } = makePopper(makeConnectedElement(), makeConnectedElement(), { enabled: false });
+
+            expect(state.isEnabled).toBe(false);
+            expect(state.updateBound).toBeUndefined();
+            expect(state.target).toBeUndefined();
+        });
     });
 
     describe('on update', () => {
@@ -161,4 +169,23 @@ describe('[lifecycle]', () => {
         });
     });
 
+    it('methods: enable/disable', () => {
+        const removeEventListener = spyOn(window, 'removeEventListener');
+        const instance = makePopper(makeConnectedElement(), makeConnectedElement());
+        let { updateBound } = instance.state;
+
+        // disable
+        instance.disable();
+        expect(removeEventListener.calls.argsFor(0)).toEqual(['resize', updateBound]);
+        expect(removeEventListener.calls.argsFor(1)).toEqual(['scroll', updateBound]);
+        expect(instance.state.isEnabled).toBe(false);
+        expect(instance.state.updateBound).toBe(null);
+
+        // enable
+        const addEventListener = spyOn(window, 'addEventListener');
+        instance.enable();
+        expect(addEventListener.calls.argsFor(0)).toEqual(['resize', instance.state.updateBound, { passive: true }]);
+        expect(addEventListener.calls.argsFor(1)).toEqual(['scroll', instance.state.updateBound, { passive: true }]);
+        expect(instance.state.isEnabled).toBe(true);
+    });
 });


### PR DESCRIPTION
Added what we talked about in https://github.com/FezVrasta/popper.js/issues/117

- [x] new boolean option `enabled` where user can decide whether popper is enabled by default or not
- [x] added enable/disable methods
- [x] tests for the changes
- [ ] missing changes in the docs