### PR TITLE
get rid of DOM manipulations that cause reflows

### DIFF
--- a/src/popper/utils/getOuterSizes.js
+++ b/src/popper/utils/getOuterSizes.js
@@ -6,14 +6,6 @@
  * @returns {Object} object containing width and height properties
  */
 export default function getOuterSizes(element) {
-    // NOTE: 1 DOM access here
-    const display = element.style.display;
-    const visibility = element.style.visibility;
-
-    element.style.display = 'block';
-    element.style.visibility = 'hidden';
-
-    // original method
     const styles = window.getComputedStyle(element);
     const x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
     const y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);
@@ -21,10 +13,5 @@ export default function getOuterSizes(element) {
         width: element.offsetWidth + y,
         height: element.offsetHeight + x
     };
-
-    // reset element styles
-    element.style.display = display;
-    element.style.visibility = visibility;
-
     return result;
 }


### PR DESCRIPTION
Removing these lines, our updates takes 0.33ms instead of 1ms, it's a huge improvement!

@rafaelverger may you please test this PR and let me know what happens?

You initially inserted these lines in https://github.com/FezVrasta/popper.js/commit/660849a3e6d73d0b6d502b2db0ed1d6cd330be9d but I'm not sure they are needed anymore since removing them the tests are passing.

You have more context than me about these changes so I would like to get feedbacks from you before merging.