### PR TITLE
make karma (and rollup) ignore the tooltip dist files

### DIFF
--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -50,7 +50,7 @@ module.exports = function(config) {
             }
         },
         preprocessors: {
-            [`${root}/src/**/*.js`]: ['rollup'],
+            [`${root}/src/(!dist|**)/*.js`]: ['rollup'],
             [`${root}/tests/**/*.js`]: ['rollup'],
         },
         rollupPreprocessor: {


### PR DESCRIPTION
Most likely we'll want to change the files structure or move Tooltip.js to its own repository in the future.