### PR TITLE
Fixing position documentation

### DIFF
--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -81,7 +81,7 @@ Create a new Popper.js instance
 | reference | <code>HTMLElement</code> |  | The reference element used to position the popper |
 | popper | <code>HTMLElement</code> |  | The HTML element used as popper. |
 | options | <code>Object</code> |  |  |
-| options.placement | <code>String</code> | <code>bottom</code> | Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),      left(-start, -end)` |
+| options.placement | <code>String</code> | <code>bottom</code> | Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -end),      left(-start, -end)` |
 | options.eventsEnabled | <code>Boolean</code> | <code>true</code> | Whether events (resize, scroll) are initially enabled |
 | options.gpuAcceleration | <code>Boolean</code> | <code>true</code> | When this property is set to true, the popper position will be applied using CSS3 translate3d, allowing the      browser to use the GPU to accelerate the rendering.      If set to false, the popper will be placed using `top` and `left` properties, not using the GPU. |
 | options.removeOnDestroy | <code>Boolean</code> | <code>false</code> | Set to true if you want to automatically remove the popper when you call the `destroy` method. |

--- a/docs/_includes/tooltip-documentation.md
+++ b/docs/_includes/tooltip-documentation.md
@@ -19,7 +19,7 @@ Create a new Tooltip.js instance
 | --- | --- | --- | --- |
 | reference | <code>HTMLElement</code> |  | The reference element used to position the tooltip |
 | options | <code>Object</code> |  |  |
-| options.placement | <code>String</code> | <code>bottom</code> | Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),      left(-start, -end)` |
+| options.placement | <code>String</code> | <code>bottom</code> | Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -end),      left(-start, -end)` |
 | reference | <code>HTMLElement</code> |  | The DOM node used as reference of the tooltip (it can be a jQuery element). |
 | options | <code>Object</code> |  | Configuration of the tooltip |
 | options.container | <code>HTMLElement</code> &#124; <code>String</code> &#124; <code>false</code> | <code>false</code> | Append the tooltip to a specific element. |

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -58,7 +58,7 @@ const DEFAULTS = {
  * @param {HTMLElement} popper - The HTML element used as popper.
  * @param {Object} options
  * @param {String} options.placement=bottom
- *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),
+ *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -end),
  *      left(-start, -end)`
  *
  * @param {Boolean} options.eventsEnabled=true

--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -18,7 +18,7 @@ export default class Tooltip {
      * @param {HTMLElement} reference - The reference element used to position the tooltip
      * @param {Object} options
      * @param {String} options.placement=bottom
-     *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -right),
+     *      Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -end),
      *      left(-start, -end)`
      *
      * @param {HTMLElement} reference - The DOM node used as reference of the tooltip (it can be a jQuery element).


### PR DESCRIPTION
The position for "bottom-end" was wrong in the documentation, it said "bottom-right". I fixed those typos.

Sorry for the 4 commits, I did the edits on github, you should squash them when you merge it :)