### PR TITLE
define popper alias only during tests (fix #144)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,7 @@
 {
     "presets": ["stage-2"],
     "plugins": [
-        "external-helpers",
-        ["module-alias", [
-            { "src": "./src/popper/index.js", "expose": "popper.js" }
-        ]]
+        "external-helpers"
     ],
     "env": {
         "coverage": {

--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -69,6 +69,11 @@ module.exports = function(config) {
                     ['es2015', { modules: false }],
                     'stage-2',
                 ],
+                plugins: [
+                    ['module-alias', [
+                        { src: './src/popper/index.js', expose: 'popper.js' },
+                    ]],
+                ],
             })],
         },
         files: [


### PR DESCRIPTION
This should fix problems with webpack. ping @Spone

To test this out you have to clone the repository, run `yarn build:tooltip` (or `npm run build:tooltip`) and copy the `dist/tooltip*` to `node_modules/tooltip.js/dist`.

Please let me know if this fixes the problem once for all.