### PR TITLE
[fix]: Importing into universal apps

### DIFF
--- a/src/popper/utils/debounce.js
+++ b/src/popper/utils/debounce.js
@@ -1,9 +1,10 @@
 import isNative from './isNative';
 
+const isBrowser = typeof window !== 'undefined';
 const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
 let timeoutDuration = 0;
 for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {
-    if (navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
+    if (isBrowser && navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
         timeoutDuration = 1;
         break;
     }
@@ -50,7 +51,7 @@ export function taskDebounce(fn) {
 // these rely on Mutation Events which only occur when an element is connected
 // to the DOM. The algorithm used in this module does not use a connected element,
 // and so we must ensure that a *native* MutationObserver is available.
-const supportsNativeMutationObserver = isNative(window.MutationObserver);
+const supportsNativeMutationObserver = isBrowser && isNative(window.MutationObserver);
 
 /**
 * Create a debounced version of a method, that's asynchronously deferred


### PR DESCRIPTION
Currently the [util/debounce.js](https://github.com/FezVrasta/popper.js/blob/master/src/popper/utils/debounce.js) file is accessing `navigator` and `window` objects at the time of import. This causes universal applications that involve any server side rendering/static generation to fail on importing Popper.js. 

I understand this is a client side library, and I'm not entirely sure where the responsibility should be placed to gracefully handle this, but conditional imports are nasty, and I don't think attaching mock objects to `global` should be the way to go. 

_If_ you're ok with this fix, as for testing the _"universalness"_ in the future, I don't know much about Karma (I'm a mocha man) but a very quick search and I can't see a way to emulate a non-browser env?