### PR TITLE
fix: Transpile to ES5 the `module` bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ node_modules
 .jekyll-metadata
 dist
 .idea/
+*.log
 
 # When you switch branches, things can get messy
 _site

--- a/.npmignore
+++ b/.npmignore
@@ -4,7 +4,7 @@
 
 # Exclude the tooltip dist files
 #===============================
-dist/tooltip*
+dist/**/tooltip*
 
 # Exclude everything else
 #========================

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "popper.js",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "A kickass library to manage your poppers",
-  "main": "dist/popper.es5.js",
-  "module": "dist/popper.js",
+  "main": "dist/umd/popper.js",
+  "module": "dist/esm/popper.js",
   "scripts": {
     "prepublish": "in-publish && npm run build || exit 0 ",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\"",

--- a/scripts/rollup.config.js
+++ b/scripts/rollup.config.js
@@ -3,33 +3,36 @@ import babel from 'rollup-plugin-babel';
 const ROOT = `${__dirname}/..`;
 const ES5 = process.env.ES5;
 const BUILD = process.env.BUILD;
+const EXT = process.env.EXT || '';
+const FORMAT = process.env.FORMAT || 'es';
 
 const babelConfig = ES5
   ? {
     presets: [['es2015', { modules: false }], 'stage-2'],
   }
-  : {};
-const es5Ext = ES5 ? '.es5' : '';
+  : {
+    presets: ['stage-2'],
+  };
 
 let entry, dest, moduleName, sourceMapFile;
 switch (BUILD) {
   case 'popper':
     moduleName = 'Popper';
     entry = `${ROOT}/src/popper/index.js`;
-    dest = `${ROOT}/dist/popper${es5Ext}.js`;
-    sourceMapFile = `${ROOT}/dist/popper${es5Ext}.js.map`;
+    dest = `${ROOT}/dist/${EXT}/popper.js`;
+    sourceMapFile = `${ROOT}/dist/${EXT}/popper.js.map`;
     break;
   case 'popper-utils':
     moduleName = 'PopperUtils';
     entry = `${ROOT}/src/popper/utils/index.js`;
-    dest = `${ROOT}/dist/popper-utils${es5Ext}.js`;
-    sourceMapFile = `${ROOT}/dist/popper-utils${es5Ext}.js.map`;
+    dest = `${ROOT}/dist/${EXT}/popper-utils.js`;
+    sourceMapFile = `${ROOT}/dist/${EXT}/popper-utils.js.map`;
     break;
   case 'tooltip':
     moduleName = 'Tooltip';
     entry = `${ROOT}/src/tooltip/index.js`;
-    dest = `${ROOT}/dist/tooltip${es5Ext}.js`;
-    sourceMapFile = `${ROOT}/dist/tooltip${es5Ext}.js.map`;
+    dest = `${ROOT}/dist/${EXT}/tooltip.js`;
+    sourceMapFile = `${ROOT}/dist/${EXT}/tooltip.js.map`;
     break;
 }
 
@@ -37,7 +40,7 @@ export default {
   entry,
   dest,
   moduleName,
-  format: 'umd',
+  format: FORMAT,
   sourceMap: true,
   sourceMapFile,
   plugins: [babel(babelConfig)],

--- a/src/tooltip/.npmignore
+++ b/src/tooltip/.npmignore
@@ -4,4 +4,4 @@
 
 # Except the dist files
 #======================
-!dist/tooltip*
+!dist/**/tooltip*

--- a/src/tooltip/package.json
+++ b/src/tooltip/package.json
@@ -1,11 +1,12 @@
 {
   "name": "tooltip.js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A kickass library to create tooltips, based on Popper.js",
-  "main": "./dist/tooltip.es5.js",
-  "jsnext:main": "./dist/tooltip.js",
+  "main": "./dist/umd/tooltip.js",
+  "module": "./dist/esm/tooltip.js",
   "scripts": {
-    "prepublish": "(cd ../../; npm run build:tooltip) && mkdir -p ./dist && cp -R ../../dist/tooltip.* ./dist/",
+    "copy": "mkdir -p ./dist/umd && mkdir -p ./dist/esm && cp -R ../../dist/tooltip.* ./dist/ && cp -R ../../dist/umd/tooltip.* ./dist/umd/ && cp -R ../../dist/esm/tooltip.* ./dist/esm/",
+    "prepublish": "(cd ../../; npm run build:tooltip) && npm run copy",
     "test": "karma start ../../scripts/karma.conf.js"
   },
   "repository": {


### PR DESCRIPTION
Fix for #219

Now the `dist` folder has in the top directory, the ESM + ES6 code.
In the `dist/esm` folder there's the ESM + ES5 code.
In `dist/umd` there's the UMD + ES5 code.

`main` is `dist/umd/popper.js` and `module` is `dist/esm/popper.js`

```
▶ ls -R dist
esm/
umd/
popper.js
popper.js.map
popper.min.js
popper.min.js.map
tooltip.js
tooltip.js.map
tooltip.min.js
tooltip.min.js.map
popper-utils.js
popper-utils.js.map
popper-utils.min.js
popper-utils.min.js.map

dist/esm:
popper.js
popper.js.map
popper.min.js
popper.min.js.map
tooltip.js
tooltip.js.map
tooltip.min.js
tooltip.min.js.map
popper-utils.js
popper-utils.js.map
popper-utils.min.js
popper-utils.min.js.map

dist/umd:
popper.js
popper.js.map
popper.min.js
popper.min.js.map
tooltip.js
tooltip.js.map
tooltip.min.js
tooltip.min.js.map
popper-utils.js
popper-utils.js.map
popper-utils.min.js
popper-utils.min.js.map
```

/cc @treshugart for review