### PR TITLE
[update] Renamed modifier.function to modifier.fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ new Popper(reference, popper, {
         applyStyle: { enabled: false },
         applyReactStyle: {
             enabled: true,
-            function: applyReactStyle,
+            fn: applyReactStyle,
             order: 800,
         },
     },

--- a/src/popper/modifiers/index.js
+++ b/src/popper/modifiers/index.js
@@ -13,7 +13,7 @@ import inner from './inner';
  * Popper.js uses a set of 9 modifiers to provide all the basic functionalities
  * needed by the library.
  *
- * Usually you don't want to override the `order`, `function` and `onLoad` props.
+ * Usually you don't want to override the `order`, `fn` and `onLoad` props.
  * All the other properties are configurations that could be tweaked.
  * @namespace modifiers
  */
@@ -29,7 +29,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: shift,
+    fn: shift,
   },
 
   /**
@@ -44,7 +44,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: offset,
+    fn: offset,
     /** @prop {Number|String} offset=0
      * Basic usage allows a number used to nudge the popper by the given amount of pixels.
      * You can pass a percentage value as string (eg. `20%`) to nudge by the given percentage (relative to reference element size)
@@ -80,7 +80,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: preventOverflow,
+    fn: preventOverflow,
     /**
      * @prop {Array} priority=['left', 'right', 'top', 'bottom']
      * Popper will try to prevent overflow following these priorities by default,
@@ -117,7 +117,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: keepTogether,
+    fn: keepTogether,
   },
 
   /**
@@ -134,7 +134,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: arrow,
+    fn: arrow,
     /** @prop {String|HTMLElement} element='[x-arrow]' - Selector or node used as arrow */
     element: '[x-arrow]',
   },
@@ -154,7 +154,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: flip,
+    fn: flip,
     /**
      * @prop {String|Array} behavior='flip'
      * The behavior used to change the popper's placement. It can be one of
@@ -189,7 +189,7 @@ export default {
     /** @prop {Boolean} enabled=false - Whether the modifier is enabled or not */
     enabled: false,
     /** @prop {Function} */
-    function: inner,
+    fn: inner,
   },
 
   /**
@@ -205,7 +205,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: hide,
+    fn: hide,
   },
 
   /**
@@ -221,7 +221,7 @@ export default {
     /** @prop {Boolean} enabled=true - Whether the modifier is enabled or not */
     enabled: true,
     /** @prop {Function} */
-    function: applyStyle,
+    fn: applyStyle,
     /** @prop {Function} */
     onLoad: applyStyleOnLoad,
     /**

--- a/src/popper/utils/runModifiers.js
+++ b/src/popper/utils/runModifiers.js
@@ -15,8 +15,12 @@ export default function runModifiers(modifiers, data, ends) {
     : modifiers.slice(0, findIndex(modifiers, 'name', ends));
 
   modifiersToRun.forEach(modifier => {
-    if (modifier.enabled && isFunction(modifier.function)) {
-      data = modifier.function(data, modifier);
+    if (modifier.function) {
+      console.warn('`modifier.function` is deprecated, use `modifier.fn`!')
+    }
+    const fn = modifier.function || modifier.fn;
+    if (modifier.enabled && isFunction(fn)) {
+      data = fn(data, modifier);
     }
   });
 

--- a/tests/functional/core.js
+++ b/tests/functional/core.js
@@ -828,7 +828,7 @@ describe('[core]', () => {
 
     new Popper(reference, popper, {
       modifiers: {
-        hidePopper: { order: 790, enabled: true, function: hidePopper },
+        hidePopper: { order: 790, enabled: true, fn: hidePopper },
       },
       onCreate: data => {
         expect(popper.style.display).toBe('none');
@@ -849,7 +849,7 @@ describe('[core]', () => {
 
     new Popper(reference, popper, {
       modifiers: {
-        movePopper: { order: 690, enabled: true, function: movePopper },
+        movePopper: { order: 690, enabled: true, fn: movePopper },
       },
       onCreate: data => {
         expect(popper.style.top).toBe('3px');


### PR DESCRIPTION
It was an unfortunate choice to use `function` as property for the modifiers, since `function` is a reserved word 😓

Now it's called `fn`.

To keep backward compatibility, the old `function` property is still supported but will throw a warning.
Still for backward compatibility, `function` will take precedence over `fn` in case both the properties are defined, to avoid to break instances where a built-in modifier had its `function` property replaced.

I'll keep the PR here for few days to collect feedbacks and see if someone notices some hidden breaking change.