### PR TITLE
[feature] Allow math operations in offset modifier

### DIFF
--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -740,7 +740,7 @@ It can be one either `-end` or `-start`.
 The `offset` modifier can shift your popper on both its axis.
 
 It accepts the following units:
-- unitless, interpreted as pixels
+- `px` or unitless, interpreted as pixels
 - `%` or `%r`, percentage relative to the length of the reference element
 - `%p`, percentage relative to the length of the popper element
 - `vw`, CSS viewport width unit
@@ -751,13 +751,22 @@ This means that if the placement is `top` or `bottom`, the length will be the
 `width`. In case of `left` or `right`, it will be the height.
 
 You can provide a single value (as `Number` or `String`), or a pair of values
-as `String` divided by one white space.
+as `String` divided by a comma or one (or more) white spaces.
+The latter is a deprecated method because it leads to confusion and will be
+removed in v2.
+Additionally, it accepts additions and subtractions between different units.
+Note that multiplications and divisions aren't supported.
 
 Valid examples are:
-- offset: 10
-- offset: '10%'
-- offset: '10 10'
-- offset: '10% 10'
+```
+10
+'10%'
+'10, 10'
+'10%, 10'
+'10 + 10%'
+'10 - 5vh + 3%'
+'-10px + 5vh, 5px - 6%'
+```
 
 **Kind**: inner property of <code>[modifiers](#modifiers)</code>  
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popper.js",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "description": "A kickass library to manage your poppers",
   "main": "dist/umd/popper.js",
   "module": "dist/esm/popper.js",

--- a/src/popper/modifiers/index.js
+++ b/src/popper/modifiers/index.js
@@ -38,7 +38,7 @@ export default {
    * The `offset` modifier can shift your popper on both its axis.
    *
    * It accepts the following units:
-   * - unitless, interpreted as pixels
+   * - `px` or unitless, interpreted as pixels
    * - `%` or `%r`, percentage relative to the length of the reference element
    * - `%p`, percentage relative to the length of the popper element
    * - `vw`, CSS viewport width unit
@@ -49,13 +49,23 @@ export default {
    * `width`. In case of `left` or `right`, it will be the height.
    *
    * You can provide a single value (as `Number` or `String`), or a pair of values
-   * as `String` divided by one white space.
+   * as `String` divided by a comma or one (or more) white spaces.
+   * The latter is a deprecated method because it leads to confusion and will be
+   * removed in v2.
+   * Additionally, it accepts additions and subtractions between different units.
+   * Note that multiplications and divisions aren't supported.
    *
    * Valid examples are:
-   * - offset: 10
-   * - offset: '10%'
-   * - offset: '10 10'
-   * - offset: '10% 10'
+   * ```
+   * 10
+   * '10%'
+   * '10, 10'
+   * '10%, 10'
+   * '10 + 10%'
+   * '10 - 5vh + 3%'
+   * '-10px + 5vh, 5px - 6%'
+   * ```
+   *
    * @memberof modifiers
    * @inner
    */

--- a/src/popper/modifiers/offset.js
+++ b/src/popper/modifiers/offset.js
@@ -1,5 +1,159 @@
 import isNumeric from '../utils/isNumeric';
 import getClientRect from '../utils/getClientRect';
+import find from '../utils/find';
+
+/**
+ * Converts a string containing value + unit into a px value number
+ * @function
+ * @memberof {modifiers~offset}
+ * @private
+ * @argument {String} str - Value + unit string
+ * @argument {String} measurement - `height` or `width`
+ * @argument {Object} popperOffsets
+ * @argument {Object} referenceOffsets
+ * @returns {Number|String}
+ * Value in pixels, or original string if no values were extracted
+ */
+export function toValue(str, measurement, popperOffsets, referenceOffsets) {
+  // separate value from unit
+  const split = str.match(/((?:\-|\+)?\d*\.?\d*)(.*)/);
+  const value = +split[1];
+  const unit = split[2];
+
+  // If it's not a number it's an operator, I guess
+  if (!value) {
+    return str;
+  }
+
+  if (unit.indexOf('%') === 0) {
+    let element;
+    switch (unit) {
+      case '%p':
+        element = popperOffsets;
+        break;
+      case '%':
+      case '%r':
+      default:
+        element = referenceOffsets;
+    }
+
+    const rect = getClientRect(element);
+    return rect[measurement] / 100 * value;
+  } else if (unit === 'vh' || unit === 'vw') {
+    // if is a vh or vw, we calculate the size based on the viewport
+    let size;
+    if (unit === 'vh') {
+      size = Math.max(
+        document.documentElement.clientHeight,
+        window.innerHeight || 0
+      );
+    } else {
+      size = Math.max(
+        document.documentElement.clientWidth,
+        window.innerWidth || 0
+      );
+    }
+    return size / 100 * value;
+  } else {
+    // if is an explicit pixel unit, we get rid of the unit and keep the value
+    // if is an implicit unit, it's px, and we return just the value
+    return value;
+  }
+}
+
+/**
+ * Parse an `offset` string to extrapolate `x` and `y` numeric offsets.
+ * @function
+ * @memberof {modifiers~offset}
+ * @private
+ * @argument {String} offset
+ * @argument {Object} popperOffsets
+ * @argument {Object} referenceOffsets
+ * @argument {String} basePlacement
+ * @returns {Array} a two cells array with x and y offsets in numbers
+ */
+export function parseOffset(
+  offset,
+  popperOffsets,
+  referenceOffsets,
+  basePlacement
+) {
+  const offsets = [0, 0];
+
+  // Use height if placement is left or right and index is 0 otherwise use width
+  // in this way the first offset will use an axis and the second one
+  // will use the other one
+  const useHeight = ['right', 'left'].indexOf(basePlacement) !== -1;
+
+  // Split the offset string to obtain a list of values and operands
+  // The regex addresses values with the plus or minus sign in front (+10, -20, etc)
+  const fragments = offset.split(/(\+|\-)/).map(frag => frag.trim());
+
+  // Detect if the offset string contains a pair of values or a single one
+  // they could be separated by comma or space
+  const divider = fragments.indexOf(
+    find(fragments, frag => frag.search(/,|\s/) !== -1)
+  );
+
+  if (fragments[divider] && fragments[divider].indexOf(',') === -1) {
+    console.warn(
+      'Offsets separated by white space(s) are deprecated, use a comma (,) instead.'
+    );
+  }
+
+  // If divider is found, we divide the list of values and operands to divide
+  // them by ofset X and Y.
+  const splitRegex = /\s*,\s*|\s+/;
+  let ops = divider !== -1
+    ? [
+      fragments
+          .slice(0, divider)
+          .concat([fragments[divider].split(splitRegex)[0]]),
+      [fragments[divider].split(splitRegex)[1]].concat(
+          fragments.slice(divider + 1)
+        ),
+    ]
+    : [fragments];
+
+  // Convert the values with units to absolute pixels to allow our computations
+  ops = ops.map((op, index) => {
+    // Most of the units rely on the orientation of the popper
+    const measurement = (index === 1 ? !useHeight : useHeight)
+      ? 'height'
+      : 'width';
+    let mergeWithPrevious = false;
+    return (
+      op
+        // This aggregates any `+` or `-` sign that aren't considered operators
+        // e.g.: 10 + +5 => [10, +, +5]
+        .reduce((a, b) => {
+          if (a[a.length - 1] === '' && ['+', '-'].indexOf(b) !== -1) {
+            a[a.length - 1] = b;
+            mergeWithPrevious = true;
+            return a;
+          } else if (mergeWithPrevious) {
+            a[a.length - 1] += b;
+            mergeWithPrevious = false;
+            return a;
+          } else {
+            return a.concat(b);
+          }
+        }, [])
+        // Here we convert the string values into number values (in px)
+        .map(str => toValue(str, measurement, popperOffsets, referenceOffsets))
+    );
+  });
+
+  // Loop trough the offsets arrays and execute the operations
+  ops.forEach((op, index) => {
+    op.forEach((frag, index2) => {
+      if (isNumeric(frag)) {
+        offsets[index] += frag * (op[index2 - 1] === '-' ? -1 : 1);
+      }
+    });
+  });
+  return offsets;
+}
 
 /**
  * @function
@@ -10,93 +164,31 @@ import getClientRect from '../utils/getClientRect';
  * The offset value as described in the modifier description
  * @returns {Object} The data object, properly modified
  */
-export default function offset(data, options) {
-  const placement = data.placement;
-  const popper = data.offsets.popper;
+export default function offset(data, { offset }) {
+  const { placement, offsets: { popper, reference } } = data;
+  const basePlacement = placement.split('-')[0];
 
   let offsets;
-  if (isNumeric(options.offset)) {
-    offsets = [options.offset, 0];
+  if (isNumeric(+offset)) {
+    offsets = [+offset, 0];
   } else {
-    // split the offset in case we are providing a pair of offsets separated
-    // by a blank space
-    offsets = options.offset.split(' ');
-
-    // itherate through each offset to compute them in case they are percentages
-    offsets = offsets.map((offset, index) => {
-      // separate value from unit
-      const split = offset.match(/(\-?\d*\.?\d*)(.*)/);
-      const value = +split[1];
-      const unit = split[2];
-
-      // use height if placement is left or right and index is 0 otherwise use width
-      // in this way the first offset will use an axis and the second one
-      // will use the other one
-      let useHeight =
-        placement.indexOf('right') !== -1 || placement.indexOf('left') !== -1;
-
-      if (index === 1) {
-        useHeight = !useHeight;
-      }
-
-      const measurement = useHeight ? 'height' : 'width';
-
-      // if is a percentage relative to the popper (%p), we calculate the value of it using
-      // as base the sizes of the popper
-      // if is a percentage (% or %r), we calculate the value of it using as base the
-      // sizes of the reference element
-      if (unit.indexOf('%') === 0) {
-        let element;
-        switch (unit) {
-          case '%p':
-            element = data.offsets.popper;
-            break;
-          case '%':
-          case '$r':
-          default:
-            element = data.offsets.reference;
-        }
-
-        const rect = getClientRect(element);
-        const len = rect[measurement];
-        return len / 100 * value;
-      } else if (unit === 'vh' || unit === 'vw') {
-        // if is a vh or vw, we calculate the size based on the viewport
-        let size;
-        if (unit === 'vh') {
-          size = Math.max(
-            document.documentElement.clientHeight,
-            window.innerHeight || 0
-          );
-        } else {
-          size = Math.max(
-            document.documentElement.clientWidth,
-            window.innerWidth || 0
-          );
-        }
-        return size / 100 * value;
-      } else if (unit === 'px') {
-        // if is an explicit pixel unit, we get rid of the unit and keep the value
-        return +value;
-      } else {
-        // if is an implicit unit, it's px, and we return just the value
-        return +offset;
-      }
-    });
+    offsets = parseOffset(offset, popper, reference, basePlacement);
   }
 
-  if (data.placement.indexOf('left') !== -1) {
+  if (basePlacement === 'left') {
     popper.top += offsets[0];
-    popper.left -= offsets[1] || 0;
-  } else if (data.placement.indexOf('right') !== -1) {
+    popper.left -= offsets[1];
+  } else if (basePlacement === 'right') {
     popper.top += offsets[0];
-    popper.left += offsets[1] || 0;
-  } else if (data.placement.indexOf('top') !== -1) {
+    popper.left += offsets[1];
+  } else if (basePlacement === 'top') {
     popper.left += offsets[0];
-    popper.top -= offsets[1] || 0;
-  } else if (data.placement.indexOf('bottom') !== -1) {
+    popper.top -= offsets[1];
+  } else if (basePlacement === 'bottom') {
     popper.left += offsets[0];
-    popper.top += offsets[1] || 0;
+    popper.top += offsets[1];
   }
+
+  data.popper = popper;
   return data;
 }

--- a/tests/functional/offset.js
+++ b/tests/functional/offset.js
@@ -20,7 +20,7 @@ describe('[offset]', () => {
           offset: offset,
         },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refWidth = reference.offsetWidth;
         const popperLeft = popper.getBoundingClientRect().left;
@@ -40,7 +40,7 @@ describe('[offset]', () => {
     reference.style.marginLeft = '100px';
     const popper = appendNewPopper(2);
 
-    const offset = '10 10';
+    const offset = '10,10';
     const arrowHeight = 5;
 
     new Popper(reference, popper, {
@@ -50,7 +50,7 @@ describe('[offset]', () => {
           offset: offset,
         },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refBottom = reference.getBoundingClientRect().bottom;
         const refWidth = reference.offsetWidth;
@@ -58,11 +58,11 @@ describe('[offset]', () => {
         const popperTop = popper.getBoundingClientRect().top;
         const popperWidth = popper.offsetWidth;
         const expectedPopperLeft =
-          refLeft + refWidth / 2 - popperWidth / 2 + +offset.split(' ')[0];
+          refLeft + refWidth / 2 - popperWidth / 2 + +offset.split(',')[0];
 
         expect(popperLeft).toBeApprox(expectedPopperLeft);
         expect(popperTop - arrowHeight).toBeApprox(
-          refBottom + +offset.split(' ')[1]
+          refBottom + +offset.split(',')[1]
         );
         data.instance.destroy();
         done();
@@ -84,7 +84,7 @@ describe('[offset]', () => {
           offset: offset,
         },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refWidth = reference.offsetWidth;
         const popperLeft = popper.getBoundingClientRect().left;
@@ -113,7 +113,7 @@ describe('[offset]', () => {
           offset: offset,
         },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refWidth = reference.offsetWidth;
         const popperLeft = popper.getBoundingClientRect().left;
@@ -133,7 +133,7 @@ describe('[offset]', () => {
     reference.style.marginLeft = '100px';
     const popper = appendNewPopper(2);
 
-    const offset = '25% 25%';
+    const offset = '25%, 25%';
     const arrowHeight = 5;
 
     new Popper(reference, popper, {
@@ -143,7 +143,7 @@ describe('[offset]', () => {
           offset: offset,
         },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refBottom = reference.getBoundingClientRect().bottom;
         const refWidth = reference.offsetWidth;
@@ -168,7 +168,7 @@ describe('[offset]', () => {
     reference.style.marginTop = '100px';
     const popper = appendNewPopper(2);
 
-    const offset = '-25% -25%';
+    const offset = '-25%, -25%';
     const arrowHeight = 5;
 
     new Popper(reference, popper, {
@@ -179,7 +179,7 @@ describe('[offset]', () => {
         },
         flip: { enabled: false },
       },
-      onCreate: (data) => {
+      onCreate: data => {
         const refLeft = reference.getBoundingClientRect().left;
         const refBottom = reference.getBoundingClientRect().bottom;
         const refWidth = reference.offsetWidth;
@@ -192,6 +192,79 @@ describe('[offset]', () => {
 
         expect(popperLeft).toBeApprox(expectedPopperLeft);
         expect(popperTop - arrowHeight).toBeApprox(refBottom - refHeight / 4);
+        data.instance.destroy();
+        done();
+      },
+    });
+  });
+
+  it('creates a popper with math operation as offset value', done => {
+    const reference = appendNewRef(1);
+    reference.style.marginLeft = '100px';
+    reference.style.marginTop = '100px';
+    const popper = appendNewPopper(2);
+
+    const offset = '5 - 25%';
+    const arrowHeight = 5;
+
+    new Popper(reference, popper, {
+      placement: 'bottom',
+      modifiers: {
+        offset: {
+          offset: offset,
+        },
+        flip: { enabled: false },
+      },
+      onCreate: data => {
+        const refLeft = reference.getBoundingClientRect().left;
+        const refBottom = reference.getBoundingClientRect().bottom;
+        const refWidth = reference.offsetWidth;
+        const popperLeft = popper.getBoundingClientRect().left;
+        const popperTop = popper.getBoundingClientRect().top;
+        const popperWidth = popper.offsetWidth;
+        const expectedPopperLeft =
+          refLeft + refWidth / 2 - popperWidth / 2 - refWidth / 4 + 5;
+
+        expect(popperLeft).toBeApprox(expectedPopperLeft);
+        expect(popperTop - arrowHeight).toBeApprox(refBottom);
+        data.instance.destroy();
+        done();
+      },
+    });
+  });
+
+  it('creates a popper with a couple of math operations as offset values', done => {
+    const reference = appendNewRef(1);
+    reference.style.marginLeft = '100px';
+    reference.style.marginTop = '100px';
+    const popper = appendNewPopper(2);
+
+    const offset = '5 - 25%, 10px + 25%';
+    const arrowHeight = 5;
+
+    new Popper(reference, popper, {
+      placement: 'bottom',
+      modifiers: {
+        offset: {
+          offset: offset,
+        },
+        flip: { enabled: false },
+      },
+      onCreate: data => {
+        const refLeft = reference.getBoundingClientRect().left;
+        const refHeight = reference.getBoundingClientRect().height;
+        const refBottom = reference.getBoundingClientRect().bottom;
+        const refWidth = reference.offsetWidth;
+        const popperLeft = popper.getBoundingClientRect().left;
+        const popperTop = popper.getBoundingClientRect().top;
+        const popperWidth = popper.offsetWidth;
+        const expectedPopperLeft =
+          refLeft + refWidth / 2 - popperWidth / 2 - refWidth / 4 + 5;
+
+        expect(popperLeft).toBeApprox(expectedPopperLeft);
+        expect(popperTop - arrowHeight).toBeApprox(
+          refBottom + refHeight / 4 + 10
+        );
         data.instance.destroy();
         done();
       },

--- a/tests/unit/parseOffset.js
+++ b/tests/unit/parseOffset.js
@@ -1,0 +1,46 @@
+import { parseOffset } from 'src/popper/modifiers/offset';
+
+const popperOffsets = {
+  top: 0,
+  left: 0,
+  right: 100,
+  bottom: 100,
+  width: 100,
+  height: 100,
+};
+
+const referenceOffsets = popperOffsets;
+
+describe('parseOffset', () => {
+  it('parses `10px 10px` and throws deprecation warning', () => {
+    console.warn = jasmine.createSpy('warn');
+    expect(
+      parseOffset('10px 10px', referenceOffsets, popperOffsets, 'bottom')
+    ).toEqual([10, 10]);
+    expect(console.warn).toHaveBeenCalledWith(
+      'Offsets separated by white space(s) are deprecated, use a comma (,) instead.'
+    );
+  });
+
+  const cases = [
+    ['10,10', [10, 10]],
+    ['10px, -10px', [10, -10]],
+    ['10px, 10px', [10, 10]],
+    ['10px + 5%, 10px - 5%', [10 + 5, 10 - 5]],
+    ['-10px + 5%, -10px - 5%', [-10 + 5, -10 - 5]],
+    ['5%p, 5%r', [5, 5]],
+    ['100%+50px, 100px-10+10%', [100 + 50, 100 - 10 + 10]],
+    ['100% + 50% + 10%, 100%', [100 + 50 + 10, 100]],
+    ['100%p - 10%r, 100%', [100 - 10, 100]],
+    ['100%p - -10%r, 100%', [100 - -10, 100]],
+    ['+10px - -10% + -10%r', [10 - -10 + -10, 0]],
+  ];
+
+  cases.forEach(([input, output]) => {
+    it(`parses '${input}'`, () => {
+      expect(
+        parseOffset(input, referenceOffsets, popperOffsets, 'bottom')
+      ).toEqual(output);
+    });
+  });
+});


### PR DESCRIPTION
fix #228, pinging @shmax for review.

New documentation:

> The `offset` modifier can shift your popper on both its axis.
> 
 > It accepts the following units:
>  - `px` or unitless, interpreted as pixels
>  - `%` or `%r`, percentage relative to the length of the reference element
>  - `%p`, percentage relative to the length of the popper element
>  - `vw`, CSS viewport width unit
> - `vh`, CSS viewport height unit
> 
>  For length is intended the main axis relative to the placement of the popper.
>  This means that if the placement is `top` or `bottom`, the length will be the
>  `width`. In case of `left` or `right`, it will be the height.
> 
>  You can provide a single value (as `Number` or `String`), or a pair of values
>  as `String` divided by a comma or one (or more) white spaces.
> The latter is a deprecated method because it leads to confusion and will be
removed in v2.
>  Additionally, it accepts additions and subtractions between dfferent unit.
>  Note that multiplications and divisions aren't spported.
> 
>  Valid examples are:
>  ```
>  10
>  '10%'
>  '10, 10'
>  '10%, 10'
>  '10 + 10%'
>  '10 - 5vh + 3%'
>  '-10px + 5vh, 5px - 6%'
>  ```