### PR TITLE
[fix] Make `auto` placement use `flip.boundariesElement`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popper.js",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "A kickass library to manage your poppers",
   "main": "dist/umd/popper.js",
   "module": "dist/esm/popper.js",

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -223,11 +223,12 @@ export default class Popper {
       this.options.placement,
       data.offsets.reference,
       this.popper,
-      this.reference
+      this.reference,
+      this.options.modifiers.flip.boundariesElement
     );
 
     // store the computed placement inside `originalPlacement`
-    data.originalPlacement = this.options.placement;
+    data.originalPlacement = data.placement;
 
     // compute the popper offsets
     data.offsets.popper = getPopperOffsets(

--- a/src/popper/modifiers/applyStyle.js
+++ b/src/popper/modifiers/applyStyle.js
@@ -84,13 +84,14 @@ export function applyStyleOnLoad(
   // compute auto placement, store placement inside the data object,
   // modifiers will be able to edit `placement` if needed
   // and refer to originalPlacement to know the original value
-  options.placement = computeAutoPlacement(
+  const placement = computeAutoPlacement(
     options.placement,
     referenceOffsets,
     popper,
-    reference
+    reference,
+    options.modifiers.flip.boundariesElement
   );
 
-  popper.setAttribute('x-placement', options.placement);
+  popper.setAttribute('x-placement', placement);
   return options;
 }

--- a/src/popper/utils/computeAutoPlacement.js
+++ b/src/popper/utils/computeAutoPlacement.js
@@ -13,13 +13,14 @@ export default function computeAutoPlacement(
   placement,
   refRect,
   popper,
-  reference
+  reference,
+  boundariesElement
 ) {
   if (placement.indexOf('auto') === -1) {
     return placement;
   }
 
-  const boundaries = getBoundaries(popper, reference, 0, 'scrollParent');
+  const boundaries = getBoundaries(popper, reference, 0, boundariesElement);
 
   const sides = {
     top: refRect.top - boundaries.top,

--- a/tests/functional/core.js
+++ b/tests/functional/core.js
@@ -20,7 +20,6 @@ describe('[core]', () => {
     jasmineWrapper.scrollLeft = 0;
   });
 
-
   it('can access the AMD module to create a new instance', () => {
     // append popper element
     const popper = document.createElement('div');
@@ -86,7 +85,9 @@ describe('[core]', () => {
   });
 
   it('inits a bottom popper inside document with margins, it should correctly flip', done => {
-    if (isIPHONE) { pending(); }
+    if (isIPHONE) {
+      pending();
+    }
 
     const doc = document.documentElement;
     doc.style.marginLeft = '50vw';
@@ -262,6 +263,7 @@ describe('[core]', () => {
 
       const pop = new Popper(reference, popper, {
         placement: 'auto',
+        modifiers: { flip: { boundariesElement: 'scrollParent' } },
         onCreate: () => {
           const bottom = getRect(popper).bottom + arrowSize;
           expect(bottom).toBeApprox(getRect(reference).top);
@@ -287,6 +289,7 @@ describe('[core]', () => {
 
       const pop = new Popper(reference, popper, {
         placement: 'auto',
+        modifiers: { flip: { boundariesElement: 'scrollParent' } },
         onCreate: () => {
           const left = getRect(popper).left - arrowSize;
           expect(left).toBeApprox(getRect(reference).right);
@@ -312,6 +315,7 @@ describe('[core]', () => {
 
       const pop = new Popper(reference, popper, {
         placement: 'auto',
+        modifiers: { flip: { boundariesElement: 'scrollParent' } },
         onCreate: () => {
           const top = getRect(popper).top - arrowSize;
           expect(top).toBeApprox(getRect(reference).bottom);
@@ -337,6 +341,7 @@ describe('[core]', () => {
 
       const pop = new Popper(reference, popper, {
         placement: 'auto',
+        modifiers: { flip: { boundariesElement: 'scrollParent' } },
         onCreate: () => {
           const right = getRect(popper).right + arrowSize;
           expect(right).toBeApprox(getRect(reference).left);
@@ -786,7 +791,9 @@ describe('[core]', () => {
   });
 
   it('inits a popper with boundariesElement set to viewport, the popper should not be in the viewport', done => {
-    if (isIPHONE) { pending(); }
+    if (isIPHONE) {
+      pending();
+    }
 
     const relative = document.createElement('div');
     relative.style.position = 'relative';


### PR DESCRIPTION
fixes #231

@imkremen may you check this out? It's enough to use this URL:
https://rawgit.com/FezVrasta/8c9b742ced8e78e45fbbc1166f366430/raw/60902150babc6dcca2541e571a4c8b48ac219d63/popper-1.8.4.js