### PR TITLE
support poppers that are children of their reference

### DIFF
--- a/src/popper/utils/findCommonOffsetParent.js
+++ b/src/popper/utils/findCommonOffsetParent.js
@@ -31,7 +31,8 @@ export default function findCommonOffsetParent(element1, element2) {
 
   // Both nodes are inside #document
   if (
-    element1 !== commonAncestorContainer && element2 !== commonAncestorContainer
+    (element1 !== commonAncestorContainer && element2 !== commonAncestorContainer)
+    || start.contains(end)
   ) {
     if (isOffsetContainer(commonAncestorContainer)) {
       return commonAncestorContainer;

--- a/tests/functional/core.js
+++ b/tests/functional/core.js
@@ -1234,6 +1234,46 @@ describe('[core]', () => {
     });
   });
 
+  it('inits a popper near the reference element when it is a child of ref and a parent is relatively positioned', done => {
+    const relative = document.createElement('div');
+    relative.style.position = 'relative';
+    relative.style.left = '50%';
+    relative.style.top = '20px';
+    relative.style.background = 'green';
+    jasmineWrapper.appendChild(relative);
+
+    const ref = appendNewRef(1, 'ref', relative);
+    const popper = appendNewPopper(2, 'popper', ref);
+
+    new Popper(ref, popper, {
+      placement: 'bottom-end',
+      onCreate: data => {
+        expect(getRect(popper).right).toBeApprox(getRect(ref).right);
+        data.instance.destroy();
+        done();
+      },
+    });
+  });
+
+  it('inits a popper near the reference element when it is a child of ref and the ref is relatively positioned', done => {
+    const ref = appendNewRef(1, 'ref');
+    ref.style.position = 'relative';
+    ref.style.left = '50px';
+    ref.style.top = '20px';
+    ref.style.background = 'green';
+
+    const popper = appendNewPopper(2, 'popper', ref);
+
+    new Popper(ref, popper, {
+      placement: 'bottom-end',
+      onCreate: data => {
+        expect(getRect(popper).right).toBeApprox(getRect(ref).right);
+        data.instance.destroy();
+        done();
+      },
+    });
+  });
+
   it('checks that all the scrollable parents have an event listener attached', done => {
     jasmineWrapper.innerHTML = `
             <div id="s1" style="overflow: scroll; height: 300px; background: red;">

--- a/tests/utils/appendNewRef.js
+++ b/tests/utils/appendNewRef.js
@@ -1,10 +1,10 @@
 export default function appendNewRef(id, text, container) {
   const jasmineWrapper = document.getElementById('jasmineWrapper');
 
-  const popper = document.createElement('div');
-  popper.id = id;
-  popper.className = 'ref';
-  popper.textContent = text || 'reference';
-  (container || jasmineWrapper).appendChild(popper);
-  return popper;
+  const ref = document.createElement('div');
+  ref.id = id;
+  ref.className = 'ref';
+  ref.textContent = text || 'reference';
+  (container || jasmineWrapper).appendChild(ref);
+  return ref;
 }


### PR DESCRIPTION
Fixes #233 

If the test coverage isn't quite there, happy to add additional tests if pointed in the right direction. I'm not quite sure where the tests for this change are/should be