### PR TITLE
fix: expectation of `window` being defined at import time

### DIFF
--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -66,6 +66,40 @@ structure of {defaults}, example:</p>
         * [.enableEventListeners()](#Popper+enableEventListeners)
         * [.disableEventListeners()](#Popper+disableEventListeners)
     * _static_
+        * ~~[.Utils](#Popper.Utils) : <code>Object</code>~~
+            * [.isNative(fn)](#Popper.Utils.isNative) ⇒ <code>boolean</code>
+            * [.debounce(fn)](#Popper.Utils.debounce) ⇒ <code>function</code>
+            * [.isNumeric(input)](#Popper.Utils.isNumeric) ⇒ <code>Boolean</code>
+            * [.setStyles(element, styles)](#Popper.Utils.setStyles)
+            * [.getSupportedPropertyName(property)](#Popper.Utils.getSupportedPropertyName) ⇒ <code>String</code>
+            * [.getRoot(node)](#Popper.Utils.getRoot) ⇒ <code>Element</code>
+            * [.getOffsetParent(element)](#Popper.Utils.getOffsetParent) ⇒ <code>Element</code>
+            * [.findCommonOffsetParent(element1, element2)](#Popper.Utils.findCommonOffsetParent) ⇒ <code>Element</code>
+            * [.getStyleComputedProperty(element, property)](#Popper.Utils.getStyleComputedProperty)
+            * [.getScroll(element, side)](#Popper.Utils.getScroll) ⇒ <code>Number</code>
+            * [.getParentNode(element)](#Popper.Utils.getParentNode) ⇒ <code>Element</code>
+            * [.getScrollParent(element)](#Popper.Utils.getScrollParent) ⇒ <code>Element</code>
+            * [.getClientRect(offsets)](#Popper.Utils.getClientRect) ⇒ <code>Object</code>
+            * [.runIsIE10()](#Popper.Utils.runIsIE10) ⇒ <code>Boolean</code>
+            * [.getBoundingClientRect(element)](#Popper.Utils.getBoundingClientRect) ⇒ <code>Object</code>
+            * [.getReferenceOffsets(state, popper, reference)](#Popper.Utils.getReferenceOffsets) ⇒ <code>Object</code>
+            * [.getOuterSizes(element)](#Popper.Utils.getOuterSizes) ⇒ <code>Object</code>
+            * [.getOppositePlacement(placement)](#Popper.Utils.getOppositePlacement) ⇒ <code>String</code>
+            * [.getPopperOffsets(position, popper, referenceOffsets, placement)](#Popper.Utils.getPopperOffsets) ⇒ <code>Object</code>
+            * [.isFunction(functionToCheck)](#Popper.Utils.isFunction) ⇒ <code>Boolean</code>
+            * [.find(arr, prop, value)](#Popper.Utils.find) ⇒
+            * [.findIndex(arr, prop, value)](#Popper.Utils.findIndex) ⇒
+            * [.runModifiers(data, modifiers, ends)](#Popper.Utils.runModifiers)
+            * [.isModifierEnabled()](#Popper.Utils.isModifierEnabled) ⇒ <code>Boolean</code>
+            * [.isFixed(element, customContainer)](#Popper.Utils.isFixed) ⇒ <code>Boolean</code>
+            * [.getBoundaries(data, padding, boundariesElement)](#Popper.Utils.getBoundaries) ⇒ <code>Object</code>
+            * [.computeAutoPlacement(data, options)](#Popper.Utils.computeAutoPlacement) ⇒ <code>Object</code>
+            * [.setAttributes(element, styles)](#Popper.Utils.setAttributes)
+            * [.isModifierRequired(modifiers, requestingName, requestedName)](#Popper.Utils.isModifierRequired) ⇒ <code>Boolean</code>
+            * [.getOppositeVariation(placement)](#Popper.Utils.getOppositeVariation) ⇒ <code>String</code>
+            * [.clockwise(placement, counter)](#Popper.Utils.clockwise) ⇒ <code>Array</code>
+        * [.placements](#Popper.placements) : <code>Array</code>
+        * [.Defaults](#Popper.Defaults) : <code>Object</code>
         * [.scheduleUpdate()](#Popper.scheduleUpdate)
 
 <a name="new_Popper_new"></a>
@@ -109,6 +143,445 @@ popper position when they are triggered. It also won't trigger onUpdate callback
 unless you call 'update' method manually.
 
 **Kind**: instance method of <code>[Popper](#Popper)</code>  
+<a name="Popper.Utils"></a>
+
+### ~~Popper.Utils : <code>Object</code>~~
+***Deprecated***
+
+Collection of utilities useful when writing custom modifiers.
+Starting from version 1.7, this method is available only if you
+include `popper-utils.js` before `popper.js`.
+
+**DEPRECATION**: This way to access PopperUtils is deprecated
+and will be removed in v2! Use the PopperUtils module directly instead.
+
+**Kind**: static property of <code>[Popper](#Popper)</code>  
+
+* ~~[.Utils](#Popper.Utils) : <code>Object</code>~~
+    * [.isNative(fn)](#Popper.Utils.isNative) ⇒ <code>boolean</code>
+    * [.debounce(fn)](#Popper.Utils.debounce) ⇒ <code>function</code>
+    * [.isNumeric(input)](#Popper.Utils.isNumeric) ⇒ <code>Boolean</code>
+    * [.setStyles(element, styles)](#Popper.Utils.setStyles)
+    * [.getSupportedPropertyName(property)](#Popper.Utils.getSupportedPropertyName) ⇒ <code>String</code>
+    * [.getRoot(node)](#Popper.Utils.getRoot) ⇒ <code>Element</code>
+    * [.getOffsetParent(element)](#Popper.Utils.getOffsetParent) ⇒ <code>Element</code>
+    * [.findCommonOffsetParent(element1, element2)](#Popper.Utils.findCommonOffsetParent) ⇒ <code>Element</code>
+    * [.getStyleComputedProperty(element, property)](#Popper.Utils.getStyleComputedProperty)
+    * [.getScroll(element, side)](#Popper.Utils.getScroll) ⇒ <code>Number</code>
+    * [.getParentNode(element)](#Popper.Utils.getParentNode) ⇒ <code>Element</code>
+    * [.getScrollParent(element)](#Popper.Utils.getScrollParent) ⇒ <code>Element</code>
+    * [.getClientRect(offsets)](#Popper.Utils.getClientRect) ⇒ <code>Object</code>
+    * [.runIsIE10()](#Popper.Utils.runIsIE10) ⇒ <code>Boolean</code>
+    * [.getBoundingClientRect(element)](#Popper.Utils.getBoundingClientRect) ⇒ <code>Object</code>
+    * [.getReferenceOffsets(state, popper, reference)](#Popper.Utils.getReferenceOffsets) ⇒ <code>Object</code>
+    * [.getOuterSizes(element)](#Popper.Utils.getOuterSizes) ⇒ <code>Object</code>
+    * [.getOppositePlacement(placement)](#Popper.Utils.getOppositePlacement) ⇒ <code>String</code>
+    * [.getPopperOffsets(position, popper, referenceOffsets, placement)](#Popper.Utils.getPopperOffsets) ⇒ <code>Object</code>
+    * [.isFunction(functionToCheck)](#Popper.Utils.isFunction) ⇒ <code>Boolean</code>
+    * [.find(arr, prop, value)](#Popper.Utils.find) ⇒
+    * [.findIndex(arr, prop, value)](#Popper.Utils.findIndex) ⇒
+    * [.runModifiers(data, modifiers, ends)](#Popper.Utils.runModifiers)
+    * [.isModifierEnabled()](#Popper.Utils.isModifierEnabled) ⇒ <code>Boolean</code>
+    * [.isFixed(element, customContainer)](#Popper.Utils.isFixed) ⇒ <code>Boolean</code>
+    * [.getBoundaries(data, padding, boundariesElement)](#Popper.Utils.getBoundaries) ⇒ <code>Object</code>
+    * [.computeAutoPlacement(data, options)](#Popper.Utils.computeAutoPlacement) ⇒ <code>Object</code>
+    * [.setAttributes(element, styles)](#Popper.Utils.setAttributes)
+    * [.isModifierRequired(modifiers, requestingName, requestedName)](#Popper.Utils.isModifierRequired) ⇒ <code>Boolean</code>
+    * [.getOppositeVariation(placement)](#Popper.Utils.getOppositeVariation) ⇒ <code>String</code>
+    * [.clockwise(placement, counter)](#Popper.Utils.clockwise) ⇒ <code>Array</code>
+
+<a name="Popper.Utils.isNative"></a>
+
+#### Utils.isNative(fn) ⇒ <code>boolean</code>
+Determine if a function is implemented natively (as opposed to a polyfill).
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| fn | <code>function</code> \| <code>undefined</code> | the function to check |
+
+<a name="Popper.Utils.debounce"></a>
+
+#### Utils.debounce(fn) ⇒ <code>function</code>
+Create a debounced version of a method, that's asynchronously deferred
+but called in the minimum time possible.
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type |
+| --- | --- |
+| fn | <code>function</code> | 
+
+<a name="Popper.Utils.isNumeric"></a>
+
+#### Utils.isNumeric(input) ⇒ <code>Boolean</code>
+Tells if a given input is a number
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| input | <code>\*</code> | to check |
+
+<a name="Popper.Utils.setStyles"></a>
+
+#### Utils.setStyles(element, styles)
+Set the style to the given popper
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| element | <code>Element</code> | Element to apply the style to |
+| styles | <code>Object</code> | Object with a list of properties and values which will be applied to the element |
+
+<a name="Popper.Utils.getSupportedPropertyName"></a>
+
+#### Utils.getSupportedPropertyName(property) ⇒ <code>String</code>
+Get the prefixed supported property name
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>String</code> - prefixed property (camelCase)  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| property | <code>String</code> | (camelCase) |
+
+<a name="Popper.Utils.getRoot"></a>
+
+#### Utils.getRoot(node) ⇒ <code>Element</code>
+Finds the root node (document, shadowDOM root) of the given element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Element</code> - root node  
+
+| Param | Type |
+| --- | --- |
+| node | <code>Element</code> | 
+
+<a name="Popper.Utils.getOffsetParent"></a>
+
+#### Utils.getOffsetParent(element) ⇒ <code>Element</code>
+Returns the offset parent of the given element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Element</code> - offset parent  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Element</code> | 
+
+<a name="Popper.Utils.findCommonOffsetParent"></a>
+
+#### Utils.findCommonOffsetParent(element1, element2) ⇒ <code>Element</code>
+Finds the offset parent common to the two provided nodes
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Element</code> - common offset parent  
+
+| Param | Type |
+| --- | --- |
+| element1 | <code>Element</code> | 
+| element2 | <code>Element</code> | 
+
+<a name="Popper.Utils.getStyleComputedProperty"></a>
+
+#### Utils.getStyleComputedProperty(element, property)
+Get CSS computed property of the given element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Eement</code> | 
+| property | <code>String</code> | 
+
+<a name="Popper.Utils.getScroll"></a>
+
+#### Utils.getScroll(element, side) ⇒ <code>Number</code>
+Gets the scroll value of the given element in the given side (top and left)
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Number</code> - amount of scrolled pixels  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| element | <code>Element</code> |  |  |
+| side | <code>String</code> | <code>top</code> | `top` or `left` |
+
+<a name="Popper.Utils.getParentNode"></a>
+
+#### Utils.getParentNode(element) ⇒ <code>Element</code>
+Returns the parentNode or the host of the element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Element</code> - parent  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Element</code> | 
+
+<a name="Popper.Utils.getScrollParent"></a>
+
+#### Utils.getScrollParent(element) ⇒ <code>Element</code>
+Returns the scrolling parent of the given element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Element</code> - scroll parent  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Element</code> | 
+
+<a name="Popper.Utils.getClientRect"></a>
+
+#### Utils.getClientRect(offsets) ⇒ <code>Object</code>
+Given element offsets, generate an output similar to getBoundingClientRect
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - ClientRect like output  
+
+| Param | Type |
+| --- | --- |
+| offsets | <code>Object</code> | 
+
+<a name="Popper.Utils.runIsIE10"></a>
+
+#### Utils.runIsIE10() ⇒ <code>Boolean</code>
+Tells if you are running Internet Explorer 10
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Boolean</code> - isIE10  
+<a name="Popper.Utils.getBoundingClientRect"></a>
+
+#### Utils.getBoundingClientRect(element) ⇒ <code>Object</code>
+Get bounding client rect of given element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - client rect  
+
+| Param | Type |
+| --- | --- |
+| element | <code>HTMLElement</code> | 
+
+<a name="Popper.Utils.getReferenceOffsets"></a>
+
+#### Utils.getReferenceOffsets(state, popper, reference) ⇒ <code>Object</code>
+Get offsets to the reference element
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - An object containing the offsets which will be applied to the popper  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| state | <code>Object</code> |  |
+| popper | <code>Element</code> | the popper element |
+| reference | <code>Element</code> | the reference element (the popper will be relative to this) |
+
+<a name="Popper.Utils.getOuterSizes"></a>
+
+#### Utils.getOuterSizes(element) ⇒ <code>Object</code>
+Get the outer sizes of the given element (offset size + margins)
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - object containing width and height properties  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Element</code> | 
+
+<a name="Popper.Utils.getOppositePlacement"></a>
+
+#### Utils.getOppositePlacement(placement) ⇒ <code>String</code>
+Get the opposite placement of the given one/
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>String</code> - flipped placement  
+
+| Param | Type |
+| --- | --- |
+| placement | <code>String</code> | 
+
+<a name="Popper.Utils.getPopperOffsets"></a>
+
+#### Utils.getPopperOffsets(position, popper, referenceOffsets, placement) ⇒ <code>Object</code>
+Get offsets to the popper
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - popperOffsets - An object containing the offsets which will be applied to the popper  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| position | <code>Object</code> | CSS position the Popper will get applied |
+| popper | <code>HTMLElement</code> | the popper element |
+| referenceOffsets | <code>Object</code> | the reference offsets (the popper will be relative to this) |
+| placement | <code>String</code> | one of the valid placement options |
+
+<a name="Popper.Utils.isFunction"></a>
+
+#### Utils.isFunction(functionToCheck) ⇒ <code>Boolean</code>
+Check if the given variable is a function
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Boolean</code> - answer to: is a function?  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| functionToCheck | <code>\*</code> | variable to check |
+
+<a name="Popper.Utils.find"></a>
+
+#### Utils.find(arr, prop, value) ⇒
+Mimics the `find` method of Array
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: index or -1  
+
+| Param | Type |
+| --- | --- |
+| arr | <code>Array</code> | 
+| prop |  | 
+| value |  | 
+
+<a name="Popper.Utils.findIndex"></a>
+
+#### Utils.findIndex(arr, prop, value) ⇒
+Return the index of the matching object
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: index or -1  
+
+| Param | Type |
+| --- | --- |
+| arr | <code>Array</code> | 
+| prop |  | 
+| value |  | 
+
+<a name="Popper.Utils.runModifiers"></a>
+
+#### Utils.runModifiers(data, modifiers, ends)
+Loop trough the list of modifiers and run them in order, each of them will then edit the data object
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type |
+| --- | --- |
+| data | <code>Object</code> | 
+| modifiers | <code>Array</code> | 
+| ends | <code>function</code> | 
+
+<a name="Popper.Utils.isModifierEnabled"></a>
+
+#### Utils.isModifierEnabled() ⇒ <code>Boolean</code>
+Helper used to know if the given modifier is enabled.
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+<a name="Popper.Utils.isFixed"></a>
+
+#### Utils.isFixed(element, customContainer) ⇒ <code>Boolean</code>
+Check if the given element is fixed or is inside a fixed parent
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Boolean</code> - answer to "isFixed?"  
+
+| Param | Type |
+| --- | --- |
+| element | <code>Element</code> | 
+| customContainer | <code>Element</code> | 
+
+<a name="Popper.Utils.getBoundaries"></a>
+
+#### Utils.getBoundaries(data, padding, boundariesElement) ⇒ <code>Object</code>
+Computed the boundaries limits and return them
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - Coordinates of the boundaries  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>Object</code> | Object containing the property "offsets" generated by `_getOffsets` |
+| padding | <code>Number</code> | Boundaries padding |
+| boundariesElement | <code>Element</code> | Element used to define the boundaries |
+
+<a name="Popper.Utils.computeAutoPlacement"></a>
+
+#### Utils.computeAutoPlacement(data, options) ⇒ <code>Object</code>
+Utility used to transform the `auto` placement to the placement with more
+available space.
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Object</code> - The data object, properly modified  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| data | <code>Object</code> | The data object generated by update method |
+| options | <code>Object</code> | Modifiers configuration and options |
+
+<a name="Popper.Utils.setAttributes"></a>
+
+#### Utils.setAttributes(element, styles)
+Set the attributes to the given popper
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| element | <code>Element</code> | Element to apply the attributes to |
+| styles | <code>Object</code> | Object with a list of properties and values which will be applied to the element |
+
+<a name="Popper.Utils.isModifierRequired"></a>
+
+#### Utils.isModifierRequired(modifiers, requestingName, requestedName) ⇒ <code>Boolean</code>
+Helper used to know if the given modifier depends from another one.
+It checks if the needed modifier is listed and enabled.
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| modifiers | <code>Array</code> | list of modifiers |
+| requestingName | <code>String</code> | name of requesting modifier |
+| requestedName | <code>String</code> | name of requested modifier |
+
+<a name="Popper.Utils.getOppositeVariation"></a>
+
+#### Utils.getOppositeVariation(placement) ⇒ <code>String</code>
+Get the opposite placement variation of the given one/
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>String</code> - flipped placement variation  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| placement | <code>String</code> | variation |
+
+<a name="Popper.Utils.clockwise"></a>
+
+#### Utils.clockwise(placement, counter) ⇒ <code>Array</code>
+Given an initial placement, returns all the subsequent placements
+clockwise (or counter-clockwise).
+
+**Kind**: static method of <code>[Utils](#Popper.Utils)</code>  
+**Returns**: <code>Array</code> - placements including their variations  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| placement | <code>String</code> |  | A valid placement (it accepts variations) |
+| counter | <code>Boolean</code> | <code>false</code> | Set to true to walk the placements counterclockwise |
+
+<a name="Popper.placements"></a>
+
+### Popper.placements : <code>Array</code>
+List of accepted placements to use as values of the `placement` option
+
+**Kind**: static property of <code>[Popper](#Popper)</code>  
+<a name="Popper.Defaults"></a>
+
+### Popper.Defaults : <code>Object</code>
+Default Popper.js options
+
+**Kind**: static property of <code>[Popper](#Popper)</code>  
 <a name="Popper.scheduleUpdate"></a>
 
 ### Popper.scheduleUpdate()

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -190,11 +190,11 @@ export default class Popper {
   //
 
   /**
-     * Updates the position of the popper, computing the new offsets and applying the new style
-     * Prefer `scheduleUpdate` over `update` because of performance reasons
-     * @method
-     * @memberof Popper
-     */
+   * Updates the position of the popper, computing the new offsets and applying the new style
+   * Prefer `scheduleUpdate` over `update` because of performance reasons
+   * @method
+   * @memberof Popper
+   */
   update() {
     // if popper is destroyed, don't perform any further update
     if (this.state.isDestroyed) {
@@ -252,17 +252,17 @@ export default class Popper {
   }
 
   /**
-     * Schedule an update, it will run on the next UI update available
-     * @method scheduleUpdate
-     * @memberof Popper
-     */
+   * Schedule an update, it will run on the next UI update available
+   * @method scheduleUpdate
+   * @memberof Popper
+   */
   scheduleUpdate = () => requestAnimationFrame(this.update);
 
   /**
-     * Destroy the popper
-     * @method
-     * @memberof Popper
-     */
+   * Destroy the popper
+   * @method
+   * @memberof Popper
+   */
   destroy() {
     this.state.isDestroyed = true;
 
@@ -286,11 +286,11 @@ export default class Popper {
   }
 
   /**
-     * it will add resize/scroll events and start recalculating
-     * position of the popper element when they are triggered
-     * @method
-     * @memberof Popper
-     */
+   * it will add resize/scroll events and start recalculating
+   * position of the popper element when they are triggered
+   * @method
+   * @memberof Popper
+   */
   enableEventListeners() {
     if (!this.state.eventsEnabled) {
       this.state = setupEventListeners(
@@ -303,12 +303,12 @@ export default class Popper {
   }
 
   /**
-     * it will remove resize/scroll events and won't recalculate
-     * popper position when they are triggered. It also won't trigger onUpdate callback anymore,
-     * unless you call 'update' method manually.
-     * @method
-     * @memberof Popper
-     */
+   * it will remove resize/scroll events and won't recalculate
+   * popper position when they are triggered. It also won't trigger onUpdate callback anymore,
+   * unless you call 'update' method manually.
+   * @method
+   * @memberof Popper
+   */
   disableEventListeners() {
     if (this.state.eventsEnabled) {
       window.cancelAnimationFrame(this.scheduleUpdate);
@@ -317,26 +317,36 @@ export default class Popper {
   }
 
   /**
-     * Collection of utilities useful when writing custom modifiers.
-     * Starting from version 1.7, this method is available only if you
-     * include `popper-utils.js` before `popper.js`.
-     *
-     * **DEPRECATION**: This way to access PopperUtils is deprecated
-     * and will be removed in v2! Use the PopperUtils module directly instead.
-     * @memberof Popper
-     */
+   * Collection of utilities useful when writing custom modifiers.
+   * Starting from version 1.7, this method is available only if you
+   * include `popper-utils.js` before `popper.js`.
+   *
+   * **DEPRECATION**: This way to access PopperUtils is deprecated
+   * and will be removed in v2! Use the PopperUtils module directly instead.
+   * @static
+   * @type {Object}
+   * @deprecated since version 1.8
+   * @member Utils
+   * @memberof Popper
+   */
   static Utils = (typeof window !== 'undefined' ? window : global).PopperUtils;
 
   /**
-     * List of accepted placements to use as values of the `placement` option
-     * @memberof Popper
-     */
+   * List of accepted placements to use as values of the `placement` option
+   * @static
+   * @type {Array}
+   * @member placements
+   * @memberof Popper
+   */
   static placements = placements;
 
   /**
-     * Default Popper.js options
-     * @memberof Popper
-     */
+   * Default Popper.js options
+   * @static
+   * @type {Object}
+   * @member Defaults
+   * @memberof Popper
+   */
   static Defaults = DEFAULTS;
 }
 

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -320,9 +320,12 @@ export default class Popper {
      * Collection of utilities useful when writing custom modifiers.
      * Starting from version 1.7, this method is available only if you
      * include `popper-utils.js` before `popper.js`.
+     *
+     * **DEPRECATION**: This way to access PopperUtils is deprecated
+     * and will be removed in v2! Use the PopperUtils module directly instead.
      * @memberof Popper
      */
-  static Utils = window && window.PopperUtils;
+  static Utils = (typeof window !== 'undefined' ? window : global).PopperUtils;
 
   /**
      * List of accepted placements to use as values of the `placement` option

--- a/src/popper/index.js
+++ b/src/popper/index.js
@@ -322,7 +322,7 @@ export default class Popper {
      * include `popper-utils.js` before `popper.js`.
      * @memberof Popper
      */
-  static Utils = window.PopperUtils;
+  static Utils = window && window.PopperUtils;
 
   /**
      * List of accepted placements to use as values of the `placement` option


### PR DESCRIPTION
This removes the expectation of popper that `window` is defined at import time (which is incorrect for any non-browser environment).


fixes #241 