### PR TITLE
Fix `dispose` not removing events

### DIFF
--- a/src/tooltip/index.js
+++ b/src/tooltip/index.js
@@ -241,7 +241,7 @@ export default class Tooltip {
 
       // remove event listeners
       this._events.forEach(({ func, event }) => {
-        this._tooltipNode.removeEventListener(event, func);
+        this.reference.removeEventListener(event, func);
       });
       this._events = [];
 


### PR DESCRIPTION
The events were removed from the tooltip element itself instead of the target `reference` element.