### PR TITLE
fix dataObject documentation typo

### DIFF
--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -739,7 +739,7 @@ this object get passed to modifiers and to the `onCreate` and `onUpdate` callbac
 | data.offsets | <code>Object</code> | The measurements of popper, reference and arrow elements. |
 | data.offsets.popper | <code>Object</code> | `top`, `left`, `width`, `height` values |
 | data.offsets.reference | <code>Object</code> | `top`, `left`, `width`, `height` values |
-| data.offsets.arro | <code>Object</code> | `top` and `left` offsets, only one of them will be different from 0 |
+| data.offsets.arrow | <code>Object</code> | `top` and `left` offsets, only one of them will be different from 0 |
 
 <a name="referenceObject"></a>
 

--- a/src/popper/modifiers/index.js
+++ b/src/popper/modifiers/index.js
@@ -298,5 +298,5 @@ export default {
  * @property {Object} data.offsets The measurements of popper, reference and arrow elements.
  * @property {Object} data.offsets.popper `top`, `left`, `width`, `height` values
  * @property {Object} data.offsets.reference `top`, `left`, `width`, `height` values
- * @property {Object} data.offsets.arro] `top` and `left` offsets, only one of them will be different from 0
+ * @property {Object} data.offsets.arrow] `top` and `left` offsets, only one of them will be different from 0
  */


### PR DESCRIPTION
- the reference to `data.offsets.arro` should mean `data.offsets.arrow`

PR conditions:
1. Tests are passing;
2. No additional tests needed as this PR addresses documentation;
