### PR TITLE
Added cached math methods to prevent namespace pollution

### DIFF
--- a/src/popper/modifiers/applyStyle.js
+++ b/src/popper/modifiers/applyStyle.js
@@ -3,6 +3,7 @@ import setStyles from '../utils/setStyles';
 import setAttributes from '../utils/setAttributes';
 import getReferenceOffsets from '../utils/getReferenceOffsets';
 import computeAutoPlacement from '../utils/computeAutoPlacement';
+import mathRound from '../utils/mathRound';
 
 /**
  * @function
@@ -25,8 +26,8 @@ export default function applyStyle(data, options) {
   };
 
   // round top and left to avoid blurry text
-  const left = Math.round(data.offsets.popper.left);
-  const top = Math.round(data.offsets.popper.top);
+  const left = mathRound(data.offsets.popper.left);
+  const top = mathRound(data.offsets.popper.top);
 
   // if gpuAcceleration is set to true and transform is supported,
   //  we use `translate3d` to apply the position to the popper we

--- a/src/popper/modifiers/arrow.js
+++ b/src/popper/modifiers/arrow.js
@@ -1,6 +1,8 @@
 import getClientRect from '../utils/getClientRect';
 import getOuterSizes from '../utils/getOuterSizes';
 import isModifierRequired from '../utils/isModifierRequired';
+import mathMin from '../utils/mathMin';
+import mathMax from '../utils/mathMax';
 
 /**
  * @function
@@ -69,7 +71,7 @@ export default function arrow(data, options) {
   let sideValue = center - getClientRect(data.offsets.popper)[side];
 
   // prevent arrowElement from being placed not contiguously to its popper
-  sideValue = Math.max(Math.min(popper[len] - arrowElementSize, sideValue), 0);
+  sideValue = mathMax(mathMin(popper[len] - arrowElementSize, sideValue), 0);
 
   data.arrowElement = arrowElement;
   data.offsets.arrow = {};

--- a/src/popper/modifiers/flip.js
+++ b/src/popper/modifiers/flip.js
@@ -6,6 +6,7 @@ import runModifiers from '../utils/runModifiers';
 import getBoundaries from '../utils/getBoundaries';
 import isModifierEnabled from '../utils/isModifierEnabled';
 import clockwise from '../utils/clockwise';
+import mathFloor from '../utils/mathFloor';
 
 const BEHAVIORS = {
   FLIP: 'flip',
@@ -70,22 +71,21 @@ export default function flip(data, options) {
     const refOffsets = data.offsets.reference;
 
     // using floor because the reference offsets may contain decimals we are not going to consider here
-    const floor = Math.floor;
     const overlapsRef =
       (placement === 'left' &&
-        floor(popperOffsets.right) > floor(refOffsets.left)) ||
+        mathFloor(popperOffsets.right) > mathFloor(refOffsets.left)) ||
       (placement === 'right' &&
-        floor(popperOffsets.left) < floor(refOffsets.right)) ||
+        mathFloor(popperOffsets.left) < mathFloor(refOffsets.right)) ||
       (placement === 'top' &&
-        floor(popperOffsets.bottom) > floor(refOffsets.top)) ||
+        mathFloor(popperOffsets.bottom) > mathFloor(refOffsets.top)) ||
       (placement === 'bottom' &&
-        floor(popperOffsets.top) < floor(refOffsets.bottom));
+        mathFloor(popperOffsets.top) < mathFloor(refOffsets.bottom));
 
-    const overflowsLeft = floor(popperOffsets.left) < floor(boundaries.left);
-    const overflowsRight = floor(popperOffsets.right) > floor(boundaries.right);
-    const overflowsTop = floor(popperOffsets.top) < floor(boundaries.top);
+    const overflowsLeft = mathFloor(popperOffsets.left) < mathFloor(boundaries.left);
+    const overflowsRight = mathFloor(popperOffsets.right) > mathFloor(boundaries.right);
+    const overflowsTop = mathFloor(popperOffsets.top) < mathFloor(boundaries.top);
     const overflowsBottom =
-      floor(popperOffsets.bottom) > floor(boundaries.bottom);
+      mathFloor(popperOffsets.bottom) > mathFloor(boundaries.bottom);
 
     const overflowsBoundaries =
       (placement === 'left' && overflowsLeft) ||

--- a/src/popper/modifiers/keepTogether.js
+++ b/src/popper/modifiers/keepTogether.js
@@ -1,4 +1,5 @@
 import getClientRect from '../utils/getClientRect';
+import mathFloor from '../utils/mathFloor';
 
 /**
  * @function
@@ -11,18 +12,17 @@ export default function keepTogether(data) {
   const popper = getClientRect(data.offsets.popper);
   const reference = data.offsets.reference;
   const placement = data.placement.split('-')[0];
-  const floor = Math.floor;
   const isVertical = ['top', 'bottom'].indexOf(placement) !== -1;
   const side = isVertical ? 'right' : 'bottom';
   const opSide = isVertical ? 'left' : 'top';
   const measurement = isVertical ? 'width' : 'height';
 
-  if (popper[side] < floor(reference[opSide])) {
+  if (popper[side] < mathFloor(reference[opSide])) {
     data.offsets.popper[opSide] =
-      floor(reference[opSide]) - popper[measurement];
+      mathFloor(reference[opSide]) - popper[measurement];
   }
-  if (popper[opSide] > floor(reference[side])) {
-    data.offsets.popper[opSide] = floor(reference[side]);
+  if (popper[opSide] > mathFloor(reference[side])) {
+    data.offsets.popper[opSide] = mathFloor(reference[side]);
   }
 
   return data;

--- a/src/popper/modifiers/offset.js
+++ b/src/popper/modifiers/offset.js
@@ -1,6 +1,7 @@
 import isNumeric from '../utils/isNumeric';
 import getClientRect from '../utils/getClientRect';
 import find from '../utils/find';
+import mathMax from '../utils/mathMax';
 
 /**
  * Converts a string containing value + unit into a px value number
@@ -43,12 +44,12 @@ export function toValue(str, measurement, popperOffsets, referenceOffsets) {
     // if is a vh or vw, we calculate the size based on the viewport
     let size;
     if (unit === 'vh') {
-      size = Math.max(
+      size = mathMax(
         document.documentElement.clientHeight,
         window.innerHeight || 0
       );
     } else {
-      size = Math.max(
+      size = mathMax(
         document.documentElement.clientWidth,
         window.innerWidth || 0
       );

--- a/src/popper/modifiers/preventOverflow.js
+++ b/src/popper/modifiers/preventOverflow.js
@@ -1,6 +1,8 @@
 import getClientRect from '../utils/getClientRect';
 import getOffsetParent from '../utils/getOffsetParent';
 import getBoundaries from '../utils/getBoundaries';
+import mathMin from '../utils/mathMin';
+import mathMax from '../utils/mathMax';
 
 /**
  * @function
@@ -30,7 +32,7 @@ export default function preventOverflow(data, options) {
         popper[placement] < boundaries[placement] &&
         !options.escapeWithReference
       ) {
-        value = Math.max(popper[placement], boundaries[placement]);
+        value = mathMax(popper[placement], boundaries[placement]);
       }
       return { [placement]: value };
     },
@@ -41,7 +43,7 @@ export default function preventOverflow(data, options) {
         popper[placement] > boundaries[placement] &&
         !options.escapeWithReference
       ) {
-        value = Math.min(
+        value = mathMin(
           popper[mainSide],
           boundaries[placement] -
             (placement === 'right' ? popper.width : popper.height)

--- a/src/popper/utils/getViewportOffsetRectRelativeToArtbitraryNode.js
+++ b/src/popper/utils/getViewportOffsetRectRelativeToArtbitraryNode.js
@@ -2,12 +2,13 @@ import getOffsetRectRelativeToArbitraryNode
   from './getOffsetRectRelativeToArbitraryNode';
 import getScroll from './getScroll';
 import getClientRect from './getClientRect';
+import mathMax from './mathMax';
 
 export default function getViewportOffsetRectRelativeToArtbitraryNode(element) {
   const html = window.document.documentElement;
   const relativeOffset = getOffsetRectRelativeToArbitraryNode(element, html);
-  const width = Math.max(html.clientWidth, window.innerWidth || 0);
-  const height = Math.max(html.clientHeight, window.innerHeight || 0);
+  const width = mathMax(html.clientWidth, window.innerWidth || 0);
+  const height = mathMax(html.clientHeight, window.innerHeight || 0);
 
   const scrollTop = getScroll(html);
   const scrollLeft = getScroll(html, 'left');

--- a/src/popper/utils/getWindowSizes.js
+++ b/src/popper/utils/getWindowSizes.js
@@ -1,15 +1,17 @@
+import mathMax from './mathMax';
+
 export default function getWindowSizes() {
   const body = window.document.body;
   const html = window.document.documentElement;
   return {
-    height: Math.max(
+    height: mathMax(
       body.scrollHeight,
       body.offsetHeight,
       html.clientHeight,
       html.scrollHeight,
       html.offsetHeight
     ),
-    width: Math.max(
+    width: mathMax(
       body.scrollWidth,
       body.offsetWidth,
       html.clientWidth,

--- a/src/popper/utils/index.js
+++ b/src/popper/utils/index.js
@@ -30,6 +30,10 @@ import runModifiers from './runModifiers';
 import setAttributes from './setAttributes';
 import setStyles from './setStyles';
 import setupEventListeners from './setupEventListeners';
+import mathMin from './mathMin';
+import mathMax from './mathMax';
+import mathFloor from './mathFloor';
+import mathRound from './mathRound';
 
 /** @namespace Popper.Utils */
 export default {
@@ -64,4 +68,8 @@ export default {
   setAttributes,
   setStyles,
   setupEventListeners,
+  mathMin,
+  mathMax,
+  mathFloor,
+  mathRound,
 };

--- a/src/popper/utils/mathFloor.js
+++ b/src/popper/utils/mathFloor.js
@@ -1,0 +1,6 @@
+/**
+ * Cached version of Math.floor native method
+ */
+const mathFloor = Math.floor;
+
+export default mathFloor;

--- a/src/popper/utils/mathMax.js
+++ b/src/popper/utils/mathMax.js
@@ -1,0 +1,6 @@
+/**
+ * Cached version of Math.max native method
+ */
+const mathMax = Math.max;
+
+export default mathMax;

--- a/src/popper/utils/mathMin.js
+++ b/src/popper/utils/mathMin.js
@@ -1,0 +1,6 @@
+/**
+ * Cached version of Math.min native method
+ */
+const mathMin = Math.min;
+
+export default mathMin;

--- a/src/popper/utils/mathRound.js
+++ b/src/popper/utils/mathRound.js
@@ -1,0 +1,6 @@
+/**
+ * Cached version of Math.round native method
+ */
+const mathRound = Math.round;
+
+export default mathRound;


### PR DESCRIPTION
Was annoyed that **babel-plugin-minify-builtins** was adding _Mathxxx functions to the global namespace.

Gives an extremely minor performance increase, cleaner minified output