### PR TITLE
[fix] Fixed #310

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popper.js",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "A kickass library to manage your poppers",
   "homepage": "https://popper.js.org",
   "repository": {

--- a/src/popper/modifiers/preventOverflow.js
+++ b/src/popper/modifiers/preventOverflow.js
@@ -9,8 +9,16 @@ import getBoundaries from '../utils/getBoundaries';
  * @returns {Object} The data object, properly modified
  */
 export default function preventOverflow(data, options) {
-  const boundariesElement =
+  let boundariesElement =
     options.boundariesElement || getOffsetParent(data.instance.popper);
+
+  // If offsetParent is the reference element, we really want to
+  // go one step up and use the next offsetParent as reference to
+  // avoid to make this modifier completely useless and look like broken
+  if (data.instance.reference === boundariesElement) {
+    boundariesElement = getOffsetParent(boundariesElement);
+  }
+
   const boundaries = getBoundaries(
     data.instance.popper,
     data.instance.reference,

--- a/src/popper/utils/getOffsetRectRelativeToArbitraryNode.js
+++ b/src/popper/utils/getOffsetRectRelativeToArbitraryNode.js
@@ -17,6 +17,8 @@ export default function getOffsetRectRelativeToArbitraryNode(children, parent) {
     width: childrenRect.width,
     height: childrenRect.height,
   });
+  offsets.marginTop = 0;
+  offsets.marginLeft = 0;
 
   // Subtract margins of documentElement in case it's being used as parent
   // we do this only on HTML because it's the only element that behaves

--- a/tests/functional/core.js
+++ b/tests/functional/core.js
@@ -1256,24 +1256,27 @@ describe('[core]', () => {
     });
   });
 
-  it('inits a popper near the reference element when it is a child of ref and the ref is relatively positioned', done => {
-    const ref = appendNewRef(1, 'ref');
-    ref.style.position = 'relative';
-    ref.style.left = '50px';
-    ref.style.top = '20px';
-    ref.style.background = 'green';
+  it(
+    'inits a popper near the reference element when it is a child of ref and the ref is relatively positioned',
+    done => {
+      const ref = appendNewRef(1, 'ref');
+      ref.style.position = 'relative';
+      ref.style.left = '300px';
+      ref.style.top = '20px';
+      ref.style.background = 'green';
 
-    const popper = appendNewPopper(2, 'popper', ref);
+      const popper = appendNewPopper(2, 'popper', ref);
 
-    new Popper(ref, popper, {
-      placement: 'bottom-end',
-      onCreate: data => {
-        expect(getRect(popper).right).toBeApprox(getRect(ref).right);
-        data.instance.destroy();
-        done();
-      },
-    });
-  });
+      new Popper(ref, popper, {
+        placement: 'bottom-end',
+        onCreate: data => {
+          expect(getRect(popper).right).toBeApprox(getRect(ref).right);
+          data.instance.destroy();
+          done();
+        },
+      });
+    }
+  );
 
   it('checks that all the scrollable parents have an event listener attached', done => {
     jasmineWrapper.innerHTML = `
@@ -1371,6 +1374,48 @@ describe('[core]', () => {
       },
       onUpdate(data) {
         expect(getRect(reference).bottom).toBeApprox(getRect(popper).top);
+        data.instance.destroy();
+        done();
+      },
+    });
+  });
+
+  // test for #310
+  it('properly avoids overflow when parent is transformed', done => {
+    jasmineWrapper.innerHTML = `
+      <style>
+        .transform {
+          will-change: transform;
+        }
+        #reference {
+          width: 50px;
+          height: 50px;
+          background: lightgrey;
+        }
+        #popper {
+          background: cyan;
+          width: 200px;
+          height: 100px;
+        }
+      </style>
+      <div class="transform">
+        <div id="reference">
+          Box 2
+        </div>
+        <div id="popper">
+          My Tooltip Content
+        </div>
+      </div>
+    `;
+
+    const reference = document.getElementById('reference');
+    const popper = document.getElementById('popper');
+
+    new Popper(reference, popper, {
+      placement: 'bottom',
+      onCreate(data) {
+        expect(getRect(reference).bottom).toBeApprox(getRect(popper).top);
+        expect(getRect(popper).left).toBeApprox(5);
         data.instance.destroy();
         done();
       },


### PR DESCRIPTION
So, I had to perform a kinda-major change in the way `preventOverflow` works to fix this problem.

Look like the test that checks the functionality of poppers when relative to their own reference element never worked and it completely blown up when I fixed #310 

Now, `preventOverflow` used `offsetParent` as boundaries element when the popper was child of a relative reference. This leaded to a weird behavior, because `preventOverflow` tried to avoid the popper from overflowing from the `reference` element.

If this is the correct behavior if we think about the strict requirements of `preventOverflow`, isn't a desirable behavior in any circumstance I can think of.

To avoid this problem when the popper has as boundariesElement its own reference element, I'm going to change the meaning of `offsetParent` to "_the offsetParent of both the elements, elements excluded_".

I think this shouldn't lead to any unwanted side effect, but if you can think of any, please share with me replying to this PR! (even after it's been merged)