### PR TITLE
Options.title should override title from attribute

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -182,7 +182,7 @@ export default class Tooltip {
     }
 
     // get title
-    const title = reference.getAttribute('title') || options.title;
+    const title = options.title || reference.getAttribute('title');
 
     // don't show tooltip if no title is defined
     if (!title) {


### PR DESCRIPTION
Right now, if element has `title` attribute like `<a href=".." title="google.com">Link</a>`, `title="google.com"` will override the title set through options, but it should not.

<!--
Thanks for your interest in contributing to Popper.js!  
Please, make sure to fulfill the following conditions before submitting your Pull Request.  

### Make sure to

1. Make sure the tests are passing, you can check it running `npm test` with Google Chrome installed;
2. Add any relevant test to cover the code you have changed and/or added;
-->
