### PR TITLE
Use correct casing for JavaScript vendor-prefixes

### DIFF
--- a/packages/popper/src/utils/getSupportedPropertyName.js
+++ b/packages/popper/src/utils/getSupportedPropertyName.js
@@ -3,10 +3,10 @@
  * @method
  * @memberof Popper.Utils
  * @argument {String} property (camelCase)
- * @returns {String} prefixed property (camelCase)
+ * @returns {String} prefixed property (camelCase or PascalCase, depending on the vendor prefix)
  */
 export default function getSupportedPropertyName(property) {
-  const prefixes = [false, 'ms', 'webkit', 'moz', 'o'];
+  const prefixes = [false, 'ms', 'Webkit', 'Moz', 'O'];
   const upperProp = property.charAt(0).toUpperCase() + property.slice(1);
 
   for (let i = 0; i < prefixes.length - 1; i++) {


### PR DESCRIPTION
Vendor-prefixed names are case sensitive in JavaScript. They should be:

* `ms`
* `Moz`
* `O`
* `Webkit`

Technically `webkit` is also acceptable, but I'm using the capitalized version here because if this is used in a React component, React expects it to be capitalized (and beyond that I'm not aware of the benefits of using one over the other).

Fixes #355 
