### PR TITLE
Support references within iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "bundlesize": [
     {
       "path": "./packages/popper/dist/popper.min.js",
-      "threshold": "7 Kb"
+      "threshold": "7.5 Kb"
     },
     {
       "path": "./packages/tooltip/dist/tooltip.min.js",

--- a/packages/popper/src/utils/getScrollParent.js
+++ b/packages/popper/src/utils/getScrollParent.js
@@ -10,11 +10,16 @@ import getParentNode from './getParentNode';
  */
 export default function getScrollParent(element) {
   // Return body, `getScroll` will take care to get the correct `scrollTop` from it
-  if (
-    !element ||
-    ['HTML', 'BODY', '#document'].indexOf(element.nodeName) !== -1
-  ) {
-    return window.document.body;
+  if (!element) {
+    return window.document.body
+  }
+
+  switch (element.nodeName) {
+    case 'HTML':
+    case 'BODY':
+      return element.ownerDocument.body
+    case '#document':
+      return element.body
   }
 
   // Firefox want us to check `-x` and `-y` variations as well

--- a/packages/popper/src/utils/setupEventListeners.js
+++ b/packages/popper/src/utils/setupEventListeners.js
@@ -2,7 +2,7 @@ import getScrollParent from './getScrollParent';
 
 function attachToScrollParents(scrollParent, event, callback, scrollParents) {
   const isBody = scrollParent.nodeName === 'BODY';
-  const target = isBody ? window : scrollParent;
+  const target = isBody ? scrollParent.ownerDocument.defaultView : scrollParent;
   target.addEventListener(event, callback, { passive: true });
 
   if (!isBody) {


### PR DESCRIPTION
This PR fixes an issue related to cases where references are contained within iframes, e.g.:

```html
<div class="popper">...</div>
<iframe src="..."></iframe>
```

```js
const popper = document.querySelector('.popper')
const iframe = document.querySelector('iframe')
const reference = iframe.contentDocument.querySelector('.reference')

new Popper(reference, popper, { ... })
```

The `getScrollParent()` and `setupEventListeners()` utilities will now correctly return the `body` and `window` references, respectively, of the associated iframe rather than the host frame.