### PR TITLE
fix(popper) guard against null onUpdate + onCreate methods

### DIFF
--- a/packages/popper/src/methods/defaults.js
+++ b/packages/popper/src/methods/defaults.js
@@ -42,7 +42,7 @@ export default {
    * Access Popper.js instance with `data.instance`.
    * @prop {onCreate}
    */
-  onCreate: () => {},
+  onCreate: null,
 
   /**
    * Callback called when the popper is updated, this callback is not called
@@ -52,7 +52,7 @@ export default {
    * Access Popper.js instance with `data.instance`.
    * @prop {onUpdate}
    */
-  onUpdate: () => {},
+  onUpdate: null,
 
   /**
    * List of modifiers used to modify the offsets before they are applied to the popper.

--- a/packages/popper/src/methods/update.js
+++ b/packages/popper/src/methods/update.js
@@ -62,8 +62,10 @@ export default function update() {
   // the other ones will call `onUpdate` callback
   if (!this.state.isCreated) {
     this.state.isCreated = true;
-    this.options.onCreate(data);
-  } else {
+    if (this.options.onCreate) {
+      this.options.onCreate(data);
+    }
+  } else if (this.options.onUpdate) {
     this.options.onUpdate(data);
   }
 }


### PR DESCRIPTION
No-op functions have a measurable memory and runtime impact. Better to check a boolean to see if a function should be run or not.

This has the added benefit of allowing external libs to pass in `null` values, making Popper.js slightly more ergonomic.