### PR TITLE
Rely on `ownerDocument` references for both poppers and reference elements

### DIFF
--- a/packages/popper/src/utils/getBoundaries.js
+++ b/packages/popper/src/utils/getBoundaries.js
@@ -35,10 +35,10 @@ export default function getBoundaries(
     if (boundariesElement === 'scrollParent') {
       boundariesNode = getScrollParent(getParentNode(popper));
       if (boundariesNode.nodeName === 'BODY') {
-        boundariesNode = window.document.documentElement;
+        boundariesNode = popper.ownerDocument.documentElement;
       }
     } else if (boundariesElement === 'window') {
-      boundariesNode = window.document.documentElement;
+      boundariesNode = popper.ownerDocument.documentElement;
     } else {
       boundariesNode = boundariesElement;
     }

--- a/packages/popper/src/utils/getOffsetParent.js
+++ b/packages/popper/src/utils/getOffsetParent.js
@@ -12,6 +12,10 @@ export default function getOffsetParent(element) {
   const nodeName = offsetParent && offsetParent.nodeName;
 
   if (!nodeName || nodeName === 'BODY' || nodeName === 'HTML') {
+    if (element) {
+      return element.ownerDocument.documentElement
+    }
+
     return window.document.documentElement;
   }
 

--- a/packages/popper/src/utils/getScroll.js
+++ b/packages/popper/src/utils/getScroll.js
@@ -11,8 +11,8 @@ export default function getScroll(element, side = 'top') {
   const nodeName = element.nodeName;
 
   if (nodeName === 'BODY' || nodeName === 'HTML') {
-    const html = window.document.documentElement;
-    const scrollingElement = window.document.scrollingElement || html;
+    const html = element.ownerDocument.documentElement;
+    const scrollingElement = element.ownerDocument.scrollingElement || html;
     return scrollingElement[upperSide];
   }
 

--- a/packages/popper/src/utils/getViewportOffsetRectRelativeToArtbitraryNode.js
+++ b/packages/popper/src/utils/getViewportOffsetRectRelativeToArtbitraryNode.js
@@ -3,7 +3,7 @@ import getScroll from './getScroll';
 import getClientRect from './getClientRect';
 
 export default function getViewportOffsetRectRelativeToArtbitraryNode(element) {
-  const html = window.document.documentElement;
+  const html = element.ownerDocument.documentElement;
   const relativeOffset = getOffsetRectRelativeToArbitraryNode(element, html);
   const width = Math.max(html.clientWidth, window.innerWidth || 0);
   const height = Math.max(html.clientHeight, window.innerHeight || 0);

--- a/packages/popper/src/utils/getWindow.js
+++ b/packages/popper/src/utils/getWindow.js
@@ -1,6 +1,7 @@
 /**
  * Get the window associated with the element
  * @argument {Element} element
+ * @returns {Window}
  */
 export default function getWindow(element) {
   const ownerDocument = element.ownerDocument;

--- a/packages/popper/src/utils/getWindow.js
+++ b/packages/popper/src/utils/getWindow.js
@@ -1,0 +1,8 @@
+/**
+ * Get the window associated with the element
+ * @argument {Element} element
+ */
+export default function getWindow(element) {
+  const ownerDocument = element.ownerDocument;
+  return ownerDocument ? ownerDocument.defaultView : window;
+}

--- a/packages/popper/src/utils/removeEventListeners.js
+++ b/packages/popper/src/utils/removeEventListeners.js
@@ -5,8 +5,11 @@
  * @private
  */
 export default function removeEventListeners(reference, state) {
+  const ownerDocument = reference.ownerDocument
+  const view = ownerDocument ? ownerDocument.defaultView : window;
+
   // Remove resize event listener on window
-  window.removeEventListener('resize', state.updateBound);
+  view.removeEventListener('resize', state.updateBound);
 
   // Remove scroll event listener on scroll parents
   state.scrollParents.forEach(target => {

--- a/packages/popper/src/utils/removeEventListeners.js
+++ b/packages/popper/src/utils/removeEventListeners.js
@@ -1,3 +1,5 @@
+import getWindow from './getWindow';
+
 /**
  * Remove event listeners used to update the popper position
  * @method
@@ -5,11 +7,8 @@
  * @private
  */
 export default function removeEventListeners(reference, state) {
-  const ownerDocument = reference.ownerDocument
-  const view = ownerDocument ? ownerDocument.defaultView : window;
-
   // Remove resize event listener on window
-  view.removeEventListener('resize', state.updateBound);
+  getWindow(reference).removeEventListener('resize', state.updateBound);
 
   // Remove scroll event listener on scroll parents
   state.scrollParents.forEach(target => {

--- a/packages/popper/src/utils/setupEventListeners.js
+++ b/packages/popper/src/utils/setupEventListeners.js
@@ -28,9 +28,12 @@ export default function setupEventListeners(
   state,
   updateBound
 ) {
+  const ownerDocument = reference.ownerDocument
+  const view = ownerDocument ? ownerDocument.defaultView : window;
+
   // Resize event listener on window
   state.updateBound = updateBound;
-  window.addEventListener('resize', state.updateBound, { passive: true });
+  view.addEventListener('resize', state.updateBound, { passive: true });
 
   // Scroll event listener on scroll parents
   const scrollElement = getScrollParent(reference);

--- a/packages/popper/src/utils/setupEventListeners.js
+++ b/packages/popper/src/utils/setupEventListeners.js
@@ -1,4 +1,5 @@
 import getScrollParent from './getScrollParent';
+import getWindow from './getWindow';
 
 function attachToScrollParents(scrollParent, event, callback, scrollParents) {
   const isBody = scrollParent.nodeName === 'BODY';
@@ -28,12 +29,9 @@ export default function setupEventListeners(
   state,
   updateBound
 ) {
-  const ownerDocument = reference.ownerDocument
-  const view = ownerDocument ? ownerDocument.defaultView : window;
-
   // Resize event listener on window
   state.updateBound = updateBound;
-  view.addEventListener('resize', state.updateBound, { passive: true });
+  getWindow(reference).addEventListener('resize', state.updateBound, { passive: true });
 
   // Scroll event listener on scroll parents
   const scrollElement = getScrollParent(reference);


### PR DESCRIPTION
This is a continuation of #415 that ensures that both poppers and reference elements rely on `ownerDocument` references whenever needed in order to support poppers and reference elements residing within iframes. Upon further testing I encountered some cases that #415 did not address that this PR does.