### PR TITLE
Remove event listeners properly on .dispose()

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -252,16 +252,17 @@ export default class Tooltip {
       // destroy instance
       this.popperInstance.destroy();
 
-      // remove event listeners
-      this._events.forEach(({ func, event }) => {
-        this.reference.removeEventListener(event, func);
-      });
-      this._events = [];
-
       // destroy tooltipNode
       this._tooltipNode.parentNode.removeChild(this._tooltipNode);
       this._tooltipNode = null;
     }
+    
+    // remove event listeners
+    this._events.forEach(({ func, event }) => {
+      this.reference.removeEventListener(event, func);
+    });
+    this._events = [];
+    
     return this;
   }
 


### PR DESCRIPTION
These event listeners are added at Tooltip construction time, whereas `_tooltipNode` is added the first time the tooltip is shown. That means the listeners will always be added on the target node, whether we end up showing the tooltip or not. We should then remove them regardless of the existence of `_tooltipNode`

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `npm test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
