### PR TITLE
Fix 372

### DIFF
--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -1,0 +1,55 @@
+// Type definitions for tooltip.js 1.1.5
+// Project: https://github.com/FezVrasta/popper.js/
+// Definitions by: elebetsamer <https://github.com/elebetsamer>
+
+// This file only declares the public portions of the API.
+// It should not define internal pieces such as utils or modifier details.
+
+/// <reference types="jquery"/>
+/// <reference types="popper.js"/>
+
+declare namespace Tooltip {
+  export type Placement = 'top-start'
+  | 'top'
+  | 'top-end'
+  | 'right-start'
+  | 'right'
+  | 'right-end'
+  | 'bottom-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'left-end'
+  | 'left'
+  | 'left-start';
+
+  export interface TooltipOptions {
+    placement?: Placement | ((tooltip: Element, reference: Element) => string);
+    container?: Element | string | false;
+    delay?: number | TooltipDelayOptions;
+    html?: boolean;
+    title?: Element | string | (() => string);
+    template?: string;
+    trigger?: string;
+    boundariesElement?: Element;
+    offset: number | string;
+    popperOptions: Popper.PopperOptions;
+  }
+
+  export interface TooltipDelayOptions {
+    show: number;
+    hide: number;
+  }
+}
+
+declare class Tooltip {
+  constructor(reference: Element | JQuery, options?: Tooltip.TooltipOptions);
+
+  show(): void;
+  hide(): void;
+  dispose(): void;
+  toggle(): void;
+}
+
+declare module 'tooltip.js' {
+  export default Tooltip;
+}

--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -22,12 +22,16 @@ declare namespace Tooltip {
   | 'left'
   | 'left-start';
 
+  export type PlacementFunction = (tooltip: Element, reference: Element) => string;
+
+  export type TitleFunction = () => string;
+
   export interface TooltipOptions {
-    placement?: Placement | ((tooltip: Element, reference: Element) => string);
+    placement?: Placement | PlacementFunction;
     container?: Element | string | false;
     delay?: number | TooltipDelayOptions;
     html?: boolean;
-    title?: Element | string | (() => string);
+    title?: Element | string | TitleFunction;
     template?: string;
     trigger?: string;
     boundariesElement?: Element;

--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -35,8 +35,8 @@ declare namespace Tooltip {
     template?: string;
     trigger?: string;
     boundariesElement?: Element;
-    offset: number | string;
-    popperOptions: Popper.PopperOptions;
+    offset?: number | string;
+    popperOptions?: Popper.PopperOptions;
   }
 
   export interface TooltipDelayOptions {


### PR DESCRIPTION
My attempt at creating a type definition for tooltip.js. I used the type definition from popper.js as a reference point.

This is my first attempt at writing a type definition, so it may need to be tweaked.

If everything looks good, this should close #372.