### PR TITLE
fix #437 by not using the reserved keyword function as property

### DIFF
--- a/packages/popper/src/utils/runModifiers.js
+++ b/packages/popper/src/utils/runModifiers.js
@@ -18,10 +18,10 @@ export default function runModifiers(modifiers, data, ends) {
     : modifiers.slice(0, findIndex(modifiers, 'name', ends));
 
   modifiersToRun.forEach(modifier => {
-    if (modifier.function) {
+    if (modifier['function']) { // eslint-disable-line dot-notation
       console.warn('`modifier.function` is deprecated, use `modifier.fn`!');
     }
-    const fn = modifier.function || modifier.fn;
+    const fn = modifier['function'] || modifier.fn; // eslint-disable-line dot-notation
     if (modifier.enabled && isFunction(fn)) {
       // Add properties to offsets to make them a complete clientRect object
       // we do this before each modifier to make sure the previous one doesn't


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `npm test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.
=> I did not add a test since the changed code is in an area of a deprecated property

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
