### PR TITLE
Allow DocumentFragment in Tooltip.js

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -148,8 +148,8 @@ export default class Tooltip {
 
     // add title to tooltip
     const titleNode = tooltipGenerator.querySelector(this.innerSelector);
-    if (title.nodeType === 1) {
-      // if title is a node, append it only if allowHtml is true
+    if (title.nodeType === 1 || title.nodeType === 11) {
+      // if title is a element node or document fragment, append it only if allowHtml is true
       allowHtml && titleNode.appendChild(title);
     } else if (isFunction(title)) {
       // if title is a function, call it and set innerText or innerHtml depending by `allowHtml` value


### PR DESCRIPTION
This adds support for document fragment that allows tooltips to have richer HTML content.

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `npm test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
