### PR TITLE
Don't rely only on a defined window to determine if we have a DOM

### DIFF
--- a/packages/popper/src/utils/debounce.js
+++ b/packages/popper/src/utils/debounce.js
@@ -1,6 +1,6 @@
 import isNative from './isNative';
 
-const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+const isBrowser = typeof window !== 'undefined' && window.document;
 const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
 let timeoutDuration = 0;
 for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {

--- a/packages/popper/src/utils/debounce.js
+++ b/packages/popper/src/utils/debounce.js
@@ -1,6 +1,6 @@
 import isNative from './isNative';
 
-const isBrowser = typeof window !== 'undefined' && window.document;
+const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
 let timeoutDuration = 0;
 for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {

--- a/packages/popper/src/utils/debounce.js
+++ b/packages/popper/src/utils/debounce.js
@@ -1,6 +1,6 @@
 import isNative from './isNative';
 
-const isBrowser = typeof window !== 'undefined';
+const isBrowser = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
 let timeoutDuration = 0;
 for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {


### PR DESCRIPTION
I came along this issue where certain server side renderers have window defined but no document.
This will add an additional check if `window.document` is not undefined. 