### PR TITLE
Resolve conflict in tooltip.dispose()

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -258,9 +258,11 @@ export default class Tooltip {
       });
       this._events = [];
 
-      // destroy tooltipNode
-      this._tooltipNode.parentNode.removeChild(this._tooltipNode);
-      this._tooltipNode = null;
+      // destroy tooltipNode if removeOnDestroy is not set, as popperInstance.destroy() already removes the element
+      if(!this.popperInstance.options.removeOnDestroy){
+          this._tooltipNode.parentNode.removeChild(this._tooltipNode);
+          this._tooltipNode = null;
+      }
     }
     return this;
   }


### PR DESCRIPTION
If popper.options.removeOnDestroy is set, then calling tooltip.dispose() will throw an error `removeClild() of undefined` because it is being called in tooltip.js and in popper.js. This pull request resolves this conflict.