### PR TITLE
Fix bug with `dispose()`

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -246,17 +246,17 @@ export default class Tooltip {
   }
 
   _dispose() {
+    // remove event listeners first to prevent any unexpected behaviour
+    this._events.forEach(({ func, event }) => {
+      this.reference.removeEventListener(event, func);
+    });
+    this._events = [];
+
     if (this._tooltipNode) {
       this._hide();
 
       // destroy instance
       this.popperInstance.destroy();
-
-      // remove event listeners
-      this._events.forEach(({ func, event }) => {
-        this.reference.removeEventListener(event, func);
-      });
-      this._events = [];
 
       // destroy tooltipNode if removeOnDestroy is not set, as popperInstance.destroy() already removes the element
       if(!this.popperInstance.options.removeOnDestroy){

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -112,6 +112,27 @@ describe('[tooltip.js]', () => {
         done();
       });
     });
+
+    it('should dispose tooltip despite never being shown', done => {
+      instance = new Tooltip(reference, {
+        title: 'foobar',
+      });
+
+      instance.dispose();
+
+      then(() => {
+        expect(document.querySelector('.tooltip')).toBeNull();
+      });
+
+      then(() => {
+        reference.dispatchEvent(new CustomEvent('mouseenter'));
+      });
+
+      then(() => {
+        expect(document.querySelector('.tooltip')).toBeNull();
+        done();
+      });
+    });
   });
 
   describe('container', () => {


### PR DESCRIPTION
When you call dispose() on a tip that hasn't been shown at least once, it
leaves behind some events that will still render the tip.

See issue #466

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `npm test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
