### PR TITLE
fix(tooltip): fixed #399

### DIFF
--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -376,6 +376,24 @@ describe('[tooltip.js]', () => {
       });
     });
 
+    it('should not show tooltip if mouse leaves reference before tooltip is shown', done => {
+      instance = new Tooltip(reference, {
+        title: 'foobar',
+        trigger: 'hover',
+        delay: { show: 1000, hide: 0 },
+      });
+
+      expect(document.querySelector('.tooltip')).toBeNull();
+
+      reference.dispatchEvent(new CustomEvent('mouseenter'));
+      reference.dispatchEvent(new CustomEvent('mouseleave'));
+
+      then(() => {
+        expect(document.querySelector('.tooltip')).toBeNull();
+        done();
+      });
+    });
+
     it('should hide a tooltip on click while open', done => {
       instance = new Tooltip(reference, {
         title: 'foobar',


### PR DESCRIPTION
This may introduce a possibly unwanted behavior tho.

If you have a tooltip that can be triggered both by `hover` and `click`, and you hover and then click on the reference before the tooltip has been shown, the tooltip will not get shown.

This because the first event (hover) triggers the "scheduleShow", but the second event (click) triggers the "scheduleHide".

I can't think of ways to avoid the #399 bug without introducing this behavior.