### PR TITLE
Add “How to use Popper.js in Jest” to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,47 @@ new Popper(reference, popper, {
 
 ```
 
+### How to use Popper.js in Jest
+
+It is recommended that users mock Popper.js for use in Jest tests due to some limitations of JSDOM.
+
+
+The simplest way to mock Popper.js is to place the following code in `__mocks__/popper.js.js` adjacent to your `node_modules` directory.  Jest will pick it up automatically.
+
+```js
+import PopperJs from 'popper.js';
+
+export default class Popper {
+  static placements = PopperJs.placements;
+
+  constructor() {
+    return {
+      destroy: () => {},
+      scheduleUpdate: () => {}
+    };
+  }
+}
+```
+
+Alternatively, you can manually mock Popper.js for a particular test.
+
+```js
+jest.mock('popper.js', () => {
+  const PopperJS = jest.requireActual('popper.js');
+
+  return class Popper {
+    static placements = PopperJS.placements;
+
+    constructor() {
+      return {
+        destroy: () => {},
+        scheduleUpdate: () => {}
+      };
+    }
+  };
+});
+```
+
 ### Migration from Popper.js v0
 
 Since the API changed, we prepared some migration instructions to make it easy to upgrade to


### PR DESCRIPTION
This PR adds a section entitled, “**How to use Popper.js in Jest**”, to the readme as discussed in https://github.com/FezVrasta/popper.js/issues/478

I included the section on manual mocking too, as I thought it was useful as well.  I can remove it if you'd prefer not to include it.  Otherwise feel free to edit as you see fit.