### PR TITLE
Add check if the parent element has a scrollbar to determine scroll parent

### DIFF
--- a/packages/popper/src/utils/getScrollParent.js
+++ b/packages/popper/src/utils/getScrollParent.js
@@ -24,7 +24,8 @@ export default function getScrollParent(element) {
 
   // Firefox want us to check `-x` and `-y` variations as well
   const { overflow, overflowX, overflowY } = getStyleComputedProperty(element);
-  if (/(auto|scroll)/.test(overflow + overflowY + overflowX)) {
+  if (/(auto|scroll)/.test(overflow + overflowY + overflowX) &&
+    (element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight)) {
     return element;
   }
 


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
Pretty sure `getScrollParent` tests should not be in `core` but couldn't get them to work in unit tests.

Fixes https://github.com/FezVrasta/popper.js/issues/526