### PR TITLE
Add link to minified JS file on unpkg and emphasise need to use UMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,24 @@ Find [the documentation here](docs/_includes/tooltip-documentation.md).
 ## Installation
 Popper.js is available on the following package managers and CDNs:
 
-| Source |                                                                                  |
-|:-------|:---------------------------------------------------------------------------------|
-| npm    | `npm install popper.js --save`                                                   |
-| yarn   | `yarn add popper.js`                                                             |
-| NuGet  | `PM> Install-Package popper.js`                                                  |
-| Bower  | `bower install popper.js --save`                                                 |
-| unpkg  | [`https://unpkg.com/popper.js`](https://unpkg.com/popper.js)                     |
+| Source           |                                                                                  |
+|:-----------------|:---------------------------------------------------------------------------------|
+| npm              | `npm install popper.js --save`                                                   |
+| yarn             | `yarn add popper.js`                                                             |
+| NuGet            | `PM> Install-Package popper.js`                                                  |
+| Bower            | `bower install popper.js --save`                                                 |
+| unpkg            | [`https://unpkg.com/popper.js`](https://unpkg.com/popper.js)                     |
+| unpkg, minified  | [`https://unpkg.com/popper.min.js`](https://unpkg.com/popper.min.js)             |
 
 Tooltip.js as well:
 
-| Source |                                                                                  |
-|:-------|:---------------------------------------------------------------------------------|
-| npm    | `npm install tooltip.js --save`                                                  |
-| yarn   | `yarn add tooltip.js`                                                            |
-| Bower* | `bower install tooltip.js=https://unpkg.com/tooltip.js --save`                   |
-| unpkg  | [`https://unpkg.com/tooltip.js`](https://unpkg.com/tooltip.js)                   |
+| Source           |                                                                                  |
+|:-----------------|:---------------------------------------------------------------------------------|
+| npm              | `npm install tooltip.js --save`                                                  |
+| yarn             | `yarn add tooltip.js`                                                            |
+| Bower*           | `bower install tooltip.js=https://unpkg.com/tooltip.js --save`                   |
+| unpkg            | [`https://unpkg.com/tooltip.js`](https://unpkg.com/tooltip.js)                   |
+| unpkg, minified  | [`https://unpkg.com/tooltip.min.js`](https://unpkg.com/tooltip.min.js)           |
 
 \*: Bower isn't officially supported, it can be used to install Tooltip.js only trough the unpkg.com CDN. This method has the limitation of not being able to define a specific version of the library. Bower and Popper.js suggests to use npm or Yarn for your projects.  
 For more info, [read the related issue](https://github.com/FezVrasta/popper.js/issues/390).
@@ -101,7 +103,7 @@ No idea what am I talking about? You are looking for UMD probably.
 - ESM - ES Modules: For webpack/Rollup or browser supporting the spec;
 - ESNext: Available in `/dist`, can be used with webpack and `babel-preset-env`;
 
-Make sure to use the right one for your needs. If you want to import it with a `<script>` tag, use UMD.  
+Make sure to use the right one for your needs. **If you want to import it with a `<script>` tag, use UMD.**  
 If you can't find the `/dist` folder in the Git repository, this is because the distribution files are shipped only to Bower, npm or our CDNs. You can still find them visiting `https://unpkg.com/popper.js/dist/` (or `https://unpkg.com/tooltip.js/dist/`)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -72,24 +72,24 @@ Find [the documentation here](docs/_includes/tooltip-documentation.md).
 ## Installation
 Popper.js is available on the following package managers and CDNs:
 
-| Source           |                                                                                  |
-|:-----------------|:---------------------------------------------------------------------------------|
-| npm              | `npm install popper.js --save`                                                   |
-| yarn             | `yarn add popper.js`                                                             |
-| NuGet            | `PM> Install-Package popper.js`                                                  |
-| Bower            | `bower install popper.js --save`                                                 |
-| unpkg            | [`https://unpkg.com/popper.js`](https://unpkg.com/popper.js)                     |
-| unpkg, minified  | [`https://unpkg.com/popper.min.js`](https://unpkg.com/popper.min.js)             |
+| Source           |                                                                                                                |
+|:-----------------|:---------------------------------------------------------------------------------------------------------------|
+| npm              | `npm install popper.js --save`                                                                                 |
+| yarn             | `yarn add popper.js`                                                                                           |
+| NuGet            | `PM> Install-Package popper.js`                                                                                |
+| Bower            | `bower install popper.js --save`                                                                               |
+| unpkg            | [`https://unpkg.com/popper.js`](https://unpkg.com/popper.js)                                                   |
+| unpkg, minified  | [`https://unpkg.com/popper.js/dist/umd/popper.min.js`](https://unpkg.com/popper.js/dist/umd/popper.min.js)     |
 
 Tooltip.js as well:
 
-| Source           |                                                                                  |
-|:-----------------|:---------------------------------------------------------------------------------|
-| npm              | `npm install tooltip.js --save`                                                  |
-| yarn             | `yarn add tooltip.js`                                                            |
-| Bower*           | `bower install tooltip.js=https://unpkg.com/tooltip.js --save`                   |
-| unpkg            | [`https://unpkg.com/tooltip.js`](https://unpkg.com/tooltip.js)                   |
-| unpkg, minified  | [`https://unpkg.com/tooltip.min.js`](https://unpkg.com/tooltip.min.js)           |
+| Source           |                                                                                                                |
+|:-----------------|:---------------------------------------------------------------------------------------------------------------|
+| npm              | `npm install tooltip.js --save`                                                                                |
+| yarn             | `yarn add tooltip.js`                                                                                          |
+| Bower*           | `bower install tooltip.js=https://unpkg.com/tooltip.js --save`                                                 |
+| unpkg            | [`https://unpkg.com/tooltip.js`](https://unpkg.com/tooltip.js)                                                 |
+| unpkg, minified  | [`https://unpkg.com/tooltip.js/dist/umd/tooltip.min.js`](https://unpkg.com/tooltip.js/dist/umd/tooltip.min.js) |
 
 \*: Bower isn't officially supported, it can be used to install Tooltip.js only trough the unpkg.com CDN. This method has the limitation of not being able to define a specific version of the library. Bower and Popper.js suggests to use npm or Yarn for your projects.  
 For more info, [read the related issue](https://github.com/FezVrasta/popper.js/issues/390).


### PR DESCRIPTION
This is an attempt to improve user experience for people who are not fans of JS package managers and browser-ifier transpilers.

* Added link to minified JS file — to make it more accessible to people who would rather just use a ready link to a CDN instead of investing in the npm/yarn/bower/nuget/package-manager-du-jour ecosystem.
* Emphasise need to use UMD — so it stands out to help people get stuff done if they happen to use said package manager, but don’t use webpack.