### PR TITLE
Adds support for `placement: 'center'`

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -22,7 +22,10 @@ declare namespace Popper {
     | 'bottom-start'
     | 'left-end'
     | 'left'
-    | 'left-start';
+    | 'left-start'
+    | 'center-end'
+    | 'center'
+    | 'center-start';
 
   export type Boundary = 'scrollParent' | 'viewport' | 'window';
 

--- a/packages/popper/src/methods/placements.js
+++ b/packages/popper/src/methods/placements.js
@@ -6,6 +6,7 @@
  * - `right`
  * - `bottom`
  * - `left`
+ * - `center`
  *
  * Each placement can have a variation from this list:
  * - `-start`
@@ -45,4 +46,7 @@ export default [
   'left-end',
   'left',
   'left-start',
+  'center-end',
+  'center',
+  'center-start',
 ];

--- a/packages/popper/src/utils/getPopperOffsets.js
+++ b/packages/popper/src/utils/getPopperOffsets.js
@@ -24,6 +24,7 @@ export default function getPopperOffsets(popper, referenceOffsets, placement) {
   };
 
   // depending by the popper placement we have to compute its offsets slightly differently
+  const isCenter = 'center' === placement;
   const isHoriz = ['right', 'left'].indexOf(placement) !== -1;
   const mainSide = isHoriz ? 'top' : 'left';
   const secondarySide = isHoriz ? 'left' : 'top';
@@ -34,13 +35,19 @@ export default function getPopperOffsets(popper, referenceOffsets, placement) {
     referenceOffsets[mainSide] +
     referenceOffsets[measurement] / 2 -
     popperRect[measurement] / 2;
-  if (placement === secondarySide) {
+  if (isCenter) {
+    popperOffsets[secondarySide] =
+      referenceOffsets[secondarySide] +
+      referenceOffsets[secondaryMeasurement] / 2 -
+      popperRect[secondaryMeasurement] / 2;
+  } else if (placement === secondarySide) {
     popperOffsets[secondarySide] =
       referenceOffsets[secondarySide] - popperRect[secondaryMeasurement];
   } else {
     popperOffsets[secondarySide] =
       referenceOffsets[getOppositePlacement(secondarySide)];
   }
+
 
   return popperOffsets;
 }

--- a/packages/popper/tests/functional/core.js
+++ b/packages/popper/tests/functional/core.js
@@ -184,6 +184,40 @@ const arrowSize = 5;
       });
     });
 
+    it('inits a center popper', done => {
+      const reference = appendNewRef(1);
+      const popper = appendNewPopper(2);
+
+      // try to position so the popper doesn't get shifted at the screen edges
+      reference.style.position = 'absolute';
+      reference.style.left = '50%';
+      reference.style.top = '50%';
+
+      // who would use an arrow on placement:center?
+      // (also makes diff less clean)
+      popper.removeChild(popper.querySelector('.popper__arrow'));
+
+      const pop = new Popper(reference, popper, {
+        placement: 'center',
+        onCreate(){
+          const popRect = getRect(popper);
+          const refRect = getRect(reference);
+          const diff = (a, b, field) => Math.abs(a[field] - b[field]);
+          const topDiff = diff(refRect, popRect, 'top');
+          const bottomDiff = diff(refRect, popRect, 'bottom');
+          const leftDiff = diff(refRect, popRect, 'left');
+          const rightDiff = diff(refRect, popRect, 'right');
+
+          expect(topDiff - bottomDiff, 'top v. bottom').toBeApprox(0);
+          expect(leftDiff - rightDiff, 'left v. right').toBeApprox(0);
+
+          pop.destroy();
+
+          done();
+        },
+      });
+    });
+
     describe(['inner modifier'], () => {
       it('inits a bottom inner popper', done => {
         const reference = appendNewRef(1);
@@ -1409,11 +1443,11 @@ const arrowSize = 5;
 
     it('checks cases where the reference element is fixed in scrolling parent', done => {
       jasmineWrapper.innerHTML = `
-            <div id="scroll" style="height: 100vh; overflow: scroll">                
+            <div id="scroll" style="height: 100vh; overflow: scroll">
                 <div id="reference" style="position: fixed; top: 100px; left: 100px; background: pink">reference</div>
                 <div id="popper" style="background: purple">popper</div>
                 <div style="height: 200vh"></div>
-            </div>                
+            </div>
             `;
 
       const reference = document.getElementById('reference');
@@ -1731,36 +1765,36 @@ const arrowSize = 5;
           body {
             padding: 100px;
           }
-  
+
           .scrollParent {
             height: 300px;
             width: 300px;
             overflow: auto;
             position: relative;
           }
-  
+
           .scrollContent {
             background: gray;
             padding: 1000px;
           }
-  
+
           #reference {
             background: lightgrey;
             height: 25px;
             width: 100px;
           }
-  
+
           #popper {
             background: cyan;
             height: 150px;
             width: 150px;
           }
-  
+
           [x-out-of-boundaries] {
             visibility: hidden;
           }
         </style>
-  
+
         <div class="scrollParent">
           <div class="scrollContent">
             <div id="reference">ref</div>


### PR DESCRIPTION
- Add `placement:'center'`, `placement:'center-start'`,
  `placement:'center-end'`
- Updates docs
- Updates TS definition
- Adds a basic test for `placement:'center'` without the arrow

Notes:

- There is only a basic test for `center`.  I didn't bother adding cases like scroll.  Not sure if that would be strictly necessary.
- I'm not sure whether `center-start` and `center-end` are really necessary.  I added them for consistency, but I can't think of an actual usecase.  I'm just interested in `center`.
- I also tested the `center` feature with the `cytoscape-popper` extension.  The usecase for `center` there is where you want to position some dom on top of a node.  See the screenshot for an example where I patched the demo to use `placement: 'center'`:

<img width="1143" alt="screen shot 2018-01-23 at 2 06 50 pm" src="https://user-images.githubusercontent.com/989043/35298961-d32eb454-0051-11e8-9415-c5f216db9dd9.png">


<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
