### PR TITLE
Find parents with CSS property overflow: overlay;

### DIFF
--- a/packages/popper/src/utils/getScrollParent.js
+++ b/packages/popper/src/utils/getScrollParent.js
@@ -24,7 +24,7 @@ export default function getScrollParent(element) {
 
   // Firefox want us to check `-x` and `-y` variations as well
   const { overflow, overflowX, overflowY } = getStyleComputedProperty(element);
-  if (/(auto|scroll)/.test(overflow + overflowY + overflowX)) {
+  if (/(auto|scroll|overlay)/.test(overflow + overflowY + overflowX)) {
     return element;
   }
 


### PR DESCRIPTION
Had some problems with the popups not following the scroll. Turns out we are using `overflow: overlay `. And after some digging, it seems that it is forgotten in this repo. 
(Overlay is the property of overflow that makes the scrollbar not affect the size of the element)