### PR TITLE
feat(tooltip): Added function to update the tooltip's content

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,8 @@
+checks:
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
 engines:
   duplication:
     enabled: false

--- a/docs/_includes/tooltip-documentation.md
+++ b/docs/_includes/tooltip-documentation.md
@@ -10,6 +10,7 @@
         * [.hide()](#Tooltip+hide)
         * [.dispose()](#Tooltip+dispose)
         * [.toggle()](#Tooltip+toggle)
+        * [.updateTitleContent()](#Tooltip+updateTitleContent)
     * _static_
         * [.PlacementFunction](#Tooltip.PlacementFunction) ⇒ <code>String</code>
         * [.TitleFunction](#Tooltip.TitleFunction) ⇒ <code>String</code>
@@ -28,7 +29,7 @@ Create a new Tooltip.js instance
 | options.placement | <code>String</code> | <code>bottom</code> | Placement of the popper accepted values: `top(-start, -end), right(-start, -end), bottom(-start, -end),      left(-start, -end)` |
 | options.container | <code>HTMLElement</code> \| <code>String</code> \| <code>false</code> | <code>false</code> | Append the tooltip to a specific element. |
 | options.delay | <code>Number</code> \| <code>Object</code> | <code>0</code> | Delay showing and hiding the tooltip (ms) - does not apply to manual trigger type.      If a number is supplied, delay is applied to both hide/show.      Object structure is: `{ show: 500, hide: 100 }` |
-| options.html | <code>Boolean</code> | <code>false</code> | Insert HTML into the tooltip. If false, the content will inserted with `innerText`. |
+| options.html | <code>Boolean</code> | <code>false</code> | Insert HTML into the tooltip. If false, the content will inserted with `textContent`. |
 | options.placement | <code>String</code> \| <code>PlacementFunction</code> | <code>&#x27;top&#x27;</code> | One of the allowed placements, or a function returning one of them. |
 | [options.template] | <code>String</code> | <code>&#x27;&lt;div class=&quot;tooltip&quot; role=&quot;tooltip&quot;&gt;&lt;div class=&quot;tooltip-arrow&quot;&gt;&lt;/div&gt;&lt;div class=&quot;tooltip-inner&quot;&gt;&lt;/div&gt;&lt;/div&gt;&#x27;</code> | Base HTML to used when creating the tooltip.      The tooltip's `title` will be injected into the `.tooltip-inner` or `.tooltip__inner`.      `.tooltip-arrow` or `.tooltip__arrow` will become the tooltip's arrow.      The outermost wrapper element should have the `.tooltip` class. |
 | options.title | <code>String</code> \| <code>HTMLElement</code> \| <code>TitleFunction</code> | <code>&#x27;&#x27;</code> | Default title value if `title` attribute isn't present. |
@@ -62,6 +63,17 @@ Hides and destroys an element’s tooltip.
 Toggles an element’s tooltip. This is considered a “manual” triggering of the tooltip.
 
 **Kind**: instance method of [<code>Tooltip</code>](#Tooltip)  
+<a name="Tooltip+updateTitleContent"></a>
+
+### tooltip.updateTitleContent(title)
+Updates the tooltip's title content
+
+**Kind**: instance method of [<code>Tooltip</code>](#Tooltip)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| title | <code>HTMLElement</code> \| <code>String</code> |  | The new content to use for the tooltip. This replaces the previous content using either textContent (for String) or innerHTML for HTMLElement. If ```title``` is of type HTMLElement it will only be visible if ```options.html``` is true.
+
 <a name="Tooltip.PlacementFunction"></a>
 
 ### Tooltip.PlacementFunction ⇒ <code>String</code>

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -27,7 +27,7 @@ export default class Tooltip {
    *      Delay showing and hiding the tooltip (ms) - does not apply to manual trigger type.
    *      If a number is supplied, delay is applied to both hide/show.
    *      Object structure is: `{ show: 500, hide: 100 }`
-   * @param {Boolean} options.html=false - Insert HTML into the tooltip. If false, the content will inserted with `innerText`.
+   * @param {Boolean} options.html=false - Insert HTML into the tooltip. If false, the content will inserted with `textContent`.
    * @param {String|PlacementFunction} options.placement='top' - One of the allowed placements, or a function returning one of them.
    * @param {String} [options.template='<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>']
    *      Base HTML to used when creating the tooltip.
@@ -114,6 +114,14 @@ export default class Tooltip {
     }
   };
 
+  /**
+   * Updates the tooltip's title content
+   * @method Tooltip#updateTitleContent
+   * @memberof Tooltip
+   * @param {String|HTMLElement} title - The new content to use for the title
+   */
+  updateTitleContent = (title) => this._updateTitleContent(title);
+
   //
   // Defaults
   //
@@ -152,22 +160,26 @@ export default class Tooltip {
 
     // add title to tooltip
     const titleNode = tooltipGenerator.querySelector(this.innerSelector);
+    this._addTitleContent(reference, title, allowHtml, titleNode);
+
+    // return the generated tooltip node
+    return tooltipNode;
+  }
+
+  _addTitleContent(reference, title, allowHtml, titleNode) {
     if (title.nodeType === 1 || title.nodeType === 11) {
       // if title is a element node or document fragment, append it only if allowHtml is true
       allowHtml && titleNode.appendChild(title);
     } else if (isFunction(title)) {
-      // if title is a function, call it and set innerText or innerHtml depending by `allowHtml` value
+      // if title is a function, call it and set textContent or innerHtml depending by `allowHtml` value
       const titleText = title.call(reference);
       allowHtml
         ? (titleNode.innerHTML = titleText)
-        : (titleNode.innerText = titleText);
+        : (titleNode.textContent = titleText);
     } else {
-      // if it's just a simple text, set innerText or innerHtml depending by `allowHtml` value
-      allowHtml ? (titleNode.innerHTML = title) : (titleNode.innerText = title);
+      // if it's just a simple text, set textContent or innerHtml depending by `allowHtml` value
+      allowHtml ? (titleNode.innerHTML = title) : (titleNode.textContent = title);
     }
-
-    // return the generated tooltip node
-    return tooltipNode;
   }
 
   _show(reference, options) {
@@ -413,6 +425,28 @@ export default class Tooltip {
 
     return false;
   };
+  
+  _updateTitleContent(title) {
+    if(typeof this._tooltipNode === 'undefined') {
+      if(typeof this.options.title !== 'undefined') {
+        this.options.title = title;
+      }
+      return;
+    }
+    const titleNode = this._tooltipNode.parentNode.querySelector(this.innerSelector);    
+    this._clearTitleContent(titleNode, this.options.html, this.reference.getAttribute('title') || this.options.title)
+    this._addTitleContent(this.reference, title, this.options.html, titleNode);
+    this.options.title = title;
+  }
+
+  _clearTitleContent(titleNode, allowHtml, lastTitle) {
+    if(lastTitle.nodeType === 1 || lastTitle.nodeType === 11) {
+      allowHtml && titleNode.removeChild(lastTitle);
+    } else {
+      allowHtml ? titleNode.innerHTML = '' : titleNode.textContent = '';
+    }
+  }
+
 }
 
 /**

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -12,7 +12,7 @@ function createReference() {
   reference.style.width = '100px';
   reference.style.height = '100px';
   reference.style.margin = '100px';
-  reference.innerText = 'reference';
+  reference.textContent = 'reference';
   jasmineWrapper.appendChild(reference);
 }
 
@@ -212,7 +212,7 @@ describe('[tooltip.js]', () => {
 
     it('should use a DOM node as tooltip content', done => {
       const content = document.createElement('div');
-      content.innerText = 'foobar';
+      content.textContent = 'foobar';
       instance = new Tooltip(reference, {
         title: content,
         html: true,
@@ -231,7 +231,7 @@ describe('[tooltip.js]', () => {
     it('should use a document fragment as tooltip content', done => {
       const content = document.createDocumentFragment();
       const inner = document.createElement('div');
-      inner.innerText = 'test';
+      inner.textContent = 'test';
       content.appendChild(inner);
       instance = new Tooltip(reference, {
         title: content,
@@ -282,6 +282,45 @@ describe('[tooltip.js]', () => {
         );
         done();
       });
+    });
+
+    it('should update title content with String', done => {
+      const updatedContent = 'Updated string';
+      instance = new Tooltip(reference, {
+        title: 'Constructor message',
+      });
+
+      instance.show();
+
+      instance.updateTitleContent(updatedContent);
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip .tooltip-inner').textContent
+        ).toBe(updatedContent);
+        done();
+      })
+    });
+
+    it('should update title content with HTMLElement', done => {
+      const updatedContent = 'Updated with div element';
+      const el = document.createElement('div');
+      el.textContent = updatedContent;
+      instance = new Tooltip(reference, {
+        title: 'Constructor message',
+        html: true, 
+      });
+
+      instance.show();
+
+      instance.updateTitleContent(el);
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip-inner').innerHTML
+        ).toBe(el.outerHTML);
+        done();
+      })
     });
   });
 


### PR DESCRIPTION
Tests updated, but not sure if the typescript definition should be as well, since this is a tooltip exclusive change. ❓Please let me know  
I'm reusing some code to insert the new String|HTMLElement

DEMO:
![video](https://user-images.githubusercontent.com/18427801/36119363-b5af5c00-100d-11e8-96eb-b70510478d44.gif)
