### PR TITLE
Fix javascript error "cannot find method removeChild of undefined" up…

### DIFF
--- a/packages/popper/src/methods/destroy.js
+++ b/packages/popper/src/methods/destroy.js
@@ -22,7 +22,7 @@ export default function destroy() {
 
   // remove the popper if user explicity asked for the deletion on destroy
   // do not use `remove` because IE11 doesn't support it
-  if (this.options.removeOnDestroy) {
+  if (this.options.removeOnDestroy && this.popper.parentNode) {
     this.popper.parentNode.removeChild(this.popper);
   }
   return this;

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -271,7 +271,7 @@ export default class Tooltip {
       this.popperInstance.destroy();
 
       // destroy tooltipNode if removeOnDestroy is not set, as popperInstance.destroy() already removes the element
-      if (!this.popperInstance.options.removeOnDestroy) {
+      if (!this.popperInstance.options.removeOnDestroy && this._tooltipNode.parentNode) {
         this._tooltipNode.parentNode.removeChild(this._tooltipNode);
         this._tooltipNode = null;
       }


### PR DESCRIPTION
Fix javascript error "cannot find method removeChild of undefined" upon disposing  when popper or tooltip parent node doesn't exist anymore. Typical for angular applications.

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
