### PR TITLE
using the clip-technique to hide the tooltip

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -180,7 +180,13 @@ export default class Tooltip {
 
     // if the tooltipNode already exists, just show it
     if (this._tooltipNode) {
-      this._tooltipNode.style.display = '';
+      this._tooltipNode.style.width = '';
+      this._tooltipNode.style.height = '';
+      this._tooltipNode.style.margin = '';
+      this._tooltipNode.style.padding = '';
+      this._tooltipNode.style.border = '';
+      this._tooltipNode.style.overflow = '';
+      this._tooltipNode.style.clip = '';
       this._tooltipNode.setAttribute('aria-hidden', 'false');
       this.popperInstance.update();
       return this;
@@ -251,7 +257,13 @@ export default class Tooltip {
     this._isOpen = false;
 
     // hide tooltipNode
-    this._tooltipNode.style.display = 'none';
+    this._tooltipNode.style.width = '1px';
+    this._tooltipNode.style.height = '1px';
+    this._tooltipNode.style.margin = '-1px';
+    this._tooltipNode.style.padding = '0';
+    this._tooltipNode.style.border = '0';
+    this._tooltipNode.style.overflow = 'hidden';
+    this._tooltipNode.style.clip = 'rect(1px, 1px, 1px, 1px)';
     this._tooltipNode.setAttribute('aria-hidden', 'true');
 
     return this;

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -44,7 +44,14 @@ describe('[tooltip.js]', () => {
       then(() => instance.hide());
 
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.width).toBe('1px');
+        expect(document.querySelector('.tooltip').style.height).toBe('1px');
+        expect(document.querySelector('.tooltip').style.margin).toBe('-1px');
+        expect(document.querySelector('.tooltip').style.padding).toBe('0px');
+        expect(document.querySelector('.tooltip').style.border).toBe('0px');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('hidden');
+        expect(document.querySelector('.tooltip').style.clip).toBe('rect(1px, 1px, 1px, 1px)');
+
         done();
       });
     });
@@ -71,7 +78,14 @@ describe('[tooltip.js]', () => {
       then(() => instance.toggle());
 
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.width).toBe('1px');
+        expect(document.querySelector('.tooltip').style.height).toBe('1px');
+        expect(document.querySelector('.tooltip').style.margin).toBe('-1px');
+        expect(document.querySelector('.tooltip').style.padding).toBe('0px');
+        expect(document.querySelector('.tooltip').style.border).toBe('0px');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('hidden');
+        expect(document.querySelector('.tooltip').style.clip).toBe('rect(1px, 1px, 1px, 1px)');
+
         done();
       });
     });
@@ -322,8 +336,14 @@ describe('[tooltip.js]', () => {
       reference.dispatchEvent(new CustomEvent('mouseenter'));
       then(() => reference.dispatchEvent(new CustomEvent('mouseleave')), 200);
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
-        done();
+        expect(document.querySelector('.tooltip').style.width).toBe('1px');
+        expect(document.querySelector('.tooltip').style.height).toBe('1px');
+        expect(document.querySelector('.tooltip').style.margin).toBe('-1px');
+        expect(document.querySelector('.tooltip').style.padding).toBe('0px');
+        expect(document.querySelector('.tooltip').style.border).toBe('0px');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('hidden');
+        expect(document.querySelector('.tooltip').style.clip).toBe('rect(1px, 1px, 1px, 1px)');
+done();
       }, 200);
     });
 
@@ -348,7 +368,13 @@ describe('[tooltip.js]', () => {
           .dispatchEvent(new CustomEvent('mouseleave'))
       );
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+                expect(document.querySelector('.tooltip').style.width).toBe('1px');
+        expect(document.querySelector('.tooltip').style.height).toBe('1px');
+        expect(document.querySelector('.tooltip').style.margin).toBe('-1px');
+        expect(document.querySelector('.tooltip').style.padding).toBe('0px');
+        expect(document.querySelector('.tooltip').style.border).toBe('0px');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('hidden');
+        expect(document.querySelector('.tooltip').style.clip).toBe('rect(1px, 1px, 1px, 1px)');
         done();
       }, 200);
     });
@@ -375,8 +401,14 @@ describe('[tooltip.js]', () => {
       );
       then(() => reference.dispatchEvent(new CustomEvent('mouseenter')));
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('');
-        done();
+        expect(document.querySelector('.tooltip').style.width).toBe('');
+        expect(document.querySelector('.tooltip').style.height).toBe('');
+        expect(document.querySelector('.tooltip').style.margin).toBe('');
+        expect(document.querySelector('.tooltip').style.padding).toBe('');
+        expect(document.querySelector('.tooltip').style.border).toBe('');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('');
+        expect(document.querySelector('.tooltip').style.clip).toBe('');
+      done();
       }, 200);
     });
 
@@ -425,7 +457,13 @@ describe('[tooltip.js]', () => {
       reference.dispatchEvent(new CustomEvent('click'));
       then(() => reference.dispatchEvent(new CustomEvent('click')));
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+                expect(document.querySelector('.tooltip').style.width).toBe('1px');
+        expect(document.querySelector('.tooltip').style.height).toBe('1px');
+        expect(document.querySelector('.tooltip').style.margin).toBe('-1px');
+        expect(document.querySelector('.tooltip').style.padding).toBe('0px');
+        expect(document.querySelector('.tooltip').style.border).toBe('0px');
+        expect(document.querySelector('.tooltip').style.overflow).toBe('hidden');
+        expect(document.querySelector('.tooltip').style.clip).toBe('rect(1px, 1px, 1px, 1px)');
         done();
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5030,6 +5030,10 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
+popper.js@^1.0.2:
+  version "1.12.9"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.9.tgz#0dfbc2dff96c451bb332edcfcfaaf566d331d5b3"
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"


### PR DESCRIPTION
Screenreaders can not read content thats hidden with display: none, therefor I changed the show and hide functions in tooltip.js using the clipping technique or the visuallyhidden class (also used in bootstrap).

more info can be found here: https://www.w3.org/WAI/tutorials/fundamentals/hiding/ 