### PR TITLE
Trigger a popper update when changing tooltip title

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -437,6 +437,7 @@ export default class Tooltip {
     this._clearTitleContent(titleNode, this.options.html, this.reference.getAttribute('title') || this.options.title)
     this._addTitleContent(this.reference, title, this.options.html, titleNode);
     this.options.title = title;
+    this.popperInstance.update();
   }
 
   _clearTitleContent(titleNode, allowHtml, lastTitle) {

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -322,6 +322,26 @@ describe('[tooltip.js]', () => {
         done();
       })
     });
+
+    it('should update the tooltip position when changing the title', done => {
+      const updatedContent = 'Updated string with a different length';
+      instance = new Tooltip(reference, {
+        title: 'Constructor message',
+      });
+
+      instance.show();
+
+      const oldPosition = document.querySelector('.tooltip .tooltip-inner').getBoundingClientRect().left
+
+      instance.updateTitleContent(updatedContent);
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip .tooltip-inner').getBoundingClientRect().left
+        ).not.toBe(oldPosition);
+        done();
+      })
+    });
   });
 
   describe('events', () => {


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->

Updating the title via `updateTitleContent` may cause the tooltip to be misaligned.

Triggering an update to the underlying popper instance will reposition the tooltip, fixing the issue.