### PR TITLE
Fix javascript error "cannot find method removeChild of undefined" up…

### DIFF
--- a/packages/popper/src/methods/destroy.js
+++ b/packages/popper/src/methods/destroy.js
@@ -22,7 +22,7 @@ export default function destroy() {
 
   // remove the popper if user explicity asked for the deletion on destroy
   // do not use `remove` because IE11 doesn't support it
-  if (this.options.removeOnDestroy) {
+  if (this.options.removeOnDestroy && this.popper.parentNode) {
     this.popper.parentNode.removeChild(this.popper);
   }
   return this;

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -271,7 +271,7 @@ export default class Tooltip {
       this.popperInstance.destroy();
 
       // destroy tooltipNode if removeOnDestroy is not set, as popperInstance.destroy() already removes the element
-      if (!this.popperInstance.options.removeOnDestroy) {
+      if (!this.popperInstance.options.removeOnDestroy && this._tooltipNode.parentNode) {
         this._tooltipNode.parentNode.removeChild(this._tooltipNode);
         this._tooltipNode = null;
       }


### PR DESCRIPTION
@FezVrasta Well. Dont get me wrong. No eagerness to offend anybody, frankly speaking i am surprised that you found my post offensive. Still consider this change useful, and since you didn't even read end of my post because of emotions i will create pr one more time and try to explain. 

I agree completely about necessity of preventing memory leaks and about handling of destroy beforehand but sometimes handling of disposing of parent nodes is not possible even in green and nice written projects, you may imagine how things are in old bullshit legacy code. Third party libraries are the problem, what is we dont have place to intercept datasource change, or reload triggered?

Having this check allows us to ensure that any tooltip we dont need is disposed.