### PR TITLE
TypeScript definitions: extract Behavior type

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -25,6 +25,8 @@ export type Placement = 'auto-start'
 
 export type Boundary = 'scrollParent' | 'viewport' | 'window';
 
+export type Behavior = 'flip' | 'clockwise' | 'counterclockwise';
+
 export type ModifierFn = (data: Data, options: Object) => Data;
 
 export interface BaseModifier {
@@ -49,7 +51,7 @@ export interface Modifiers {
     element?: string | Element,
   };
   flip?: BaseModifier & {
-    behavior?: 'flip' | 'clockwise' | 'counterclockwise' | Position[],
+    behavior?: Behavior | Position[],
     padding?: number,
     boundariesElement?: Boundary | Element,
   };


### PR DESCRIPTION
I extracted the _behaviors_ in their own type.
So they can be used by other libraries, especially Bootstrap v4 TypeScript definition.

@giladgray

Edit: Travis CI fail is not related to this...