### PR TITLE
Fixes typo in documentation ("neeed" to "need")

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@ layout: landing
 								<h2 id="tooltipjs" tabindex="0">Tooltip.js</h2>
 								<p>
 									Looking for a dead simple tooltip library?<br />
-									<b>Tooltip.js</b> is powered by <b>Popper.js</b> and supports all the features you may neeed for your tooltips.
+									<b>Tooltip.js</b> is powered by <b>Popper.js</b> and supports all the features you may need for your tooltips.
 								</p>
 								<p>
 									<a id="tooltip-learn-more" href="tooltip-examples.html" class="button">Learn more</a>


### PR DESCRIPTION
I had just noticed that "need" was misspelled; this just fixes that.