### PR TITLE
Fix some typos and grammar.

### DIFF
--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -9,8 +9,8 @@
 
 <dl>
 <dt><a href="#dataObject">dataObject</a></dt>
-<dd><p>The <code>dataObject</code> is an object containing all the informations used by Popper.js
-this object get passed to modifiers and to the <code>onCreate</code> and <code>onUpdate</code> callbacks.</p>
+<dd><p>The <code>dataObject</code> is an object containing all the information used by Popper.js.
+This object is passed to modifiers and to the <code>onCreate</code> and <code>onUpdate</code> callbacks.</p>
 </dd>
 <dt><a href="#referenceObject">referenceObject</a></dt>
 <dd><p>The <code>referenceObject</code> is an object that provides an interface compatible with Popper.js
@@ -18,7 +18,7 @@ and lets you use it as replacement of a real DOM node.<br />
 You can use this method to position a popper relatively to a set of coordinates
 in case you don&#39;t have a DOM node to use as reference.</p>
 <pre><code>new Popper(referenceObject, popperNode);
-</code></pre><p>NB: This feature isn&#39;t supported in Internet Explorer 10</p>
+</code></pre><p>NB: This feature isn&#39;t supported in Internet Explorer 10.</p>
 </dd>
 </dl>
 
@@ -82,30 +82,20 @@ make sure they are performant enough to avoid performance bottlenecks.</p>
 <a name="new_Popper_new"></a>
 
 ### new Popper(reference, popper, options)
-Create a new Popper.js instance
+Creates a new Popper.js instance.
 
 **Returns**: <code>Object</code> - instance - The generated Popper.js instance  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | reference | <code>HTMLElement</code> \| [<code>referenceObject</code>](#referenceObject) | The reference element used to position the popper |
-| popper | <code>HTMLElement</code> | The HTML element used as popper. |
+| popper | <code>HTMLElement</code> | The HTML element used as the popper |
 | options | <code>Object</code> | Your custom options to override the ones defined in [Defaults](#defaults) |
 
 <a name="Popper.Defaults"></a>
 
 ### Popper.Defaults : <code>Object</code>
-Default options provided to Popper.js constructor.<br />
-These can be overriden using the `options` argument of Popper.js.<br />
-To override an option, simply pass as 3rd argument an object with the same
-structure of this object, example:
-```
-new Popper(ref, pop, {
-  modifiers: {
-    preventOverflow: { enabled: false }
-  }
-})
-```
+Default options provided to Popper.js constructor.<br />These can be overridden using the `options` argument of Popper.js.<br />To override an option, simply pass an object with the samestructure of the `options` object, as the 3rd argument. For example:```new Popper(ref, pop, {  modifiers: {    preventOverflow: { enabled: false }  }})```
 
 **Kind**: static property of [<code>Popper</code>](#Popper)  
 
@@ -121,7 +111,7 @@ new Popper(ref, pop, {
 <a name="Popper.Defaults.placement"></a>
 
 #### Defaults.placement
-Popper's placement
+Popper's placement.
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -145,7 +135,7 @@ Set this to true if you want popper to position it self in 'fixed' mode
 <a name="Popper.Defaults.eventsEnabled"></a>
 
 #### Defaults.eventsEnabled
-Whether events (resize, scroll) are initially enabled
+Whether events (resize, scroll) are initially enabled.
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -157,8 +147,7 @@ Whether events (resize, scroll) are initially enabled
 <a name="Popper.Defaults.removeOnDestroy"></a>
 
 #### Defaults.removeOnDestroy
-Set to true if you want to automatically remove the popper when
-you call the `destroy` method.
+Set to true if you want to automatically remove the popper whenyou call the `destroy` method.
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -170,8 +159,7 @@ you call the `destroy` method.
 <a name="Popper.Defaults.modifiers"></a>
 
 #### Defaults.modifiers
-List of modifiers used to modify the offsets before they are applied to the popper.
-They provide most of the functionalities of Popper.js
+List of modifiers used to modify the offsets before they are applied to the popper.They provide most of the functionalities of Popper.js.
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -183,9 +171,7 @@ They provide most of the functionalities of Popper.js
 <a name="Popper.Defaults.onCreate"></a>
 
 #### Defaults.onCreate()
-Callback called when the popper is created.<br />
-By default, is set to no-op.<br />
-Access Popper.js instance with `data.instance`.
+Callback called when the popper is created.<br />By default, it is set to no-op.<br />Access Popper.js instance with `data.instance`.
 
 **Kind**: static method of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -197,11 +183,7 @@ Access Popper.js instance with `data.instance`.
 <a name="Popper.Defaults.onUpdate"></a>
 
 #### Defaults.onUpdate()
-Callback called when the popper is updated, this callback is not called
-on the initialization/creation of the popper, but only on subsequent
-updates.<br />
-By default, is set to no-op.<br />
-Access Popper.js instance with `data.instance`.
+Callback called when the popper is updated. This callback is not calledon the initialization/creation of the popper, but only on subsequentupdates.<br />By default, it is set to no-op.<br />Access Popper.js instance with `data.instance`.
 
 **Kind**: static method of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -213,71 +195,44 @@ Access Popper.js instance with `data.instance`.
 <a name="Popper.placements"></a>
 
 ### Popper.placements : <code>enum</code>
-List of accepted placements to use as values of the `placement` option.<br />
-Valid placements are:
-- `auto`
-- `top`
-- `right`
-- `bottom`
-- `left`
-
-Each placement can have a variation from this list:
-- `-start`
-- `-end`
-
-Variations are interpreted easily if you think of them as the left to right
-written languages. Horizontally (`top` and `bottom`), `start` is left and `end`
-is right.<br />
-Vertically (`left` and `right`), `start` is top and `end` is bottom.
-
-Some valid examples are:
-- `top-end` (on top of reference, right aligned)
-- `right-start` (on right of reference, top aligned)
-- `bottom` (on bottom, centered)
-- `auto-right` (on the side with more space available, alignment depends by placement)
+List of accepted placements to use as values of the `placement` option.<br />Valid placements are:- `auto`- `top`- `right`- `bottom`- `left`Each placement can have a variation from this list:- `-start`- `-end`Variations are interpreted easily if you think of them as the left to rightwritten languages. Horizontally (`top` and `bottom`), `start` is left and `end`is right.<br />Vertically (`left` and `right`), `start` is top and `end` is bottom.Some valid examples are:- `top-end` (on top of reference, right aligned)- `right-start` (on right of reference, top aligned)- `bottom` (on bottom, centered)- `auto-right` (on the side with more space available, alignment depends by placement)
 
 **Kind**: static enum of [<code>Popper</code>](#Popper)  
 **Read only**: true  
 <a name="Popper.update"></a>
 
 ### Popper.update()
-Updates the position of the popper, computing the new offsets and applying
-the new style.<br />
-Prefer `scheduleUpdate` over `update` because of performance reasons.
+Updates the position of the popper, computing the new offsets and applyingthe new style.<br />Prefer `scheduleUpdate` over `update` because of performance reasons.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.destroy"></a>
 
 ### Popper.destroy()
-Destroy the popper
+Destroys the popper.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.enableEventListeners"></a>
 
 ### Popper.enableEventListeners()
-It will add resize/scroll events and start recalculating
-position of the popper element when they are triggered.
+It will add resize/scroll events and start recalculatingposition of the popper element when they are triggered.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.disableEventListeners"></a>
 
 ### Popper.disableEventListeners()
-It will remove resize/scroll events and won't recalculate popper position
-when they are triggered. It also won't trigger onUpdate callback anymore,
-unless you call `update` method manually.
+It will remove resize/scroll events and won't recalculate popper positionwhen they are triggered. It also won't trigger `onUpdate` callback anymore,unless you call `update` method manually.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.scheduleUpdate"></a>
 
 ### Popper.scheduleUpdate()
-Schedule an update, it will run on the next UI update available
+Schedules an update. It will run on the next UI update available.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="dataObject"></a>
 
 ## dataObject
-The `dataObject` is an object containing all the informations used by Popper.js
-this object get passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
+The `dataObject` is an object containing all the information used by Popper.js.This object is passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
 
 **Kind**: global variable  
 **Properties**
@@ -288,12 +243,12 @@ this object get passed to modifiers and to the `onCreate` and `onUpdate` callbac
 | data.placement | <code>String</code> | Placement applied to popper |
 | data.originalPlacement | <code>String</code> | Placement originally defined on init |
 | data.flipped | <code>Boolean</code> | True if popper has been flipped by flip modifier |
-| data.hide | <code>Boolean</code> | True if the reference element is out of boundaries, useful to know when to hide the popper. |
+| data.hide | <code>Boolean</code> | True if the reference element is out of boundaries, useful to know when to hide the popper |
 | data.arrowElement | <code>HTMLElement</code> | Node used as arrow by arrow modifier |
-| data.styles | <code>Object</code> | Any CSS property defined here will be applied to the popper, it expects the JavaScript nomenclature (eg. `marginBottom`) |
-| data.arrowStyles | <code>Object</code> | Any CSS property defined here will be applied to the popper arrow, it expects the JavaScript nomenclature (eg. `marginBottom`) |
+| data.styles | <code>Object</code> | Any CSS property defined here will be applied to the popper. It expects the JavaScript nomenclature (eg. `marginBottom`) |
+| data.arrowStyles | <code>Object</code> | Any CSS property defined here will be applied to the popper arrow. It expects the JavaScript nomenclature (eg. `marginBottom`) |
 | data.boundaries | <code>Object</code> | Offsets of the popper boundaries |
-| data.offsets | <code>Object</code> | The measurements of popper, reference and arrow elements. |
+| data.offsets | <code>Object</code> | The measurements of popper, reference and arrow elements |
 | data.offsets.popper | <code>Object</code> | `top`, `left`, `width`, `height` values |
 | data.offsets.reference | <code>Object</code> | `top`, `left`, `width`, `height` values |
 | data.offsets.arrow | <code>Object</code> | `top` and `left` offsets, only one of them will be different from 0 |
@@ -301,16 +256,7 @@ this object get passed to modifiers and to the `onCreate` and `onUpdate` callbac
 <a name="referenceObject"></a>
 
 ## referenceObject
-The `referenceObject` is an object that provides an interface compatible with Popper.js
-and lets you use it as replacement of a real DOM node.<br />
-You can use this method to position a popper relatively to a set of coordinates
-in case you don't have a DOM node to use as reference.
-
-```
-new Popper(referenceObject, popperNode);
-```
-
-NB: This feature isn't supported in Internet Explorer 10
+The `referenceObject` is an object that provides an interface compatible with Popper.jsand lets you use it as replacement of a real DOM node.<br />You can use this method to position a popper relatively to a set of coordinatesin case you don't have a DOM node to use as reference.```new Popper(referenceObject, popperNode);```NB: This feature isn't supported in Internet Explorer 10.
 
 **Kind**: global variable  
 **Properties**
@@ -324,12 +270,7 @@ NB: This feature isn't supported in Internet Explorer 10
 <a name="modifiers"></a>
 
 ## modifiers : <code>object</code>
-Modifiers are plugins used to alter the behavior of your poppers.<br />
-Popper.js uses a set of 9 modifiers to provide all the basic functionalities
-needed by the library.
-
-Usually you don't want to override the `order`, `fn` and `onLoad` props.
-All the other properties are configurations that could be tweaked.
+Modifiers are plugins used to alter the behavior of your poppers.<br />Popper.js uses a set of 9 modifiers to provide all the basic functionalitiesneeded by the library.Usually you don't want to override the `order`, `fn` and `onLoad` props.All the other properties are configurations that could be tweaked.
 
 **Kind**: global namespace  
 
@@ -391,10 +332,7 @@ All the other properties are configurations that could be tweaked.
 <a name="modifiers..shift"></a>
 
 ### modifiers~shift
-Modifier used to shift the popper on the start or end of its reference
-element.<br />
-It will read the variation of the `placement` property.<br />
-It can be one either `-end` or `-start`.
+Modifier used to shift the popper on the start or end of its referenceelement.<br />It will read the variation of the `placement` property.<br />It can be one either `-end` or `-start`.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -436,39 +374,7 @@ It can be one either `-end` or `-start`.
 <a name="modifiers..offset"></a>
 
 ### modifiers~offset
-The `offset` modifier can shift your popper on both its axis.
-
-It accepts the following units:
-- `px` or unitless, interpreted as pixels
-- `%` or `%r`, percentage relative to the length of the reference element
-- `%p`, percentage relative to the length of the popper element
-- `vw`, CSS viewport width unit
-- `vh`, CSS viewport height unit
-
-For length is intended the main axis relative to the placement of the popper.<br />
-This means that if the placement is `top` or `bottom`, the length will be the
-`width`. In case of `left` or `right`, it will be the height.
-
-You can provide a single value (as `Number` or `String`), or a pair of values
-as `String` divided by a comma or one (or more) white spaces.<br />
-The latter is a deprecated method because it leads to confusion and will be
-removed in v2.<br />
-Additionally, it accepts additions and subtractions between different units.
-Note that multiplications and divisions aren't supported.
-
-Valid examples are:
-```
-10
-'10%'
-'10, 10'
-'10%, 10'
-'10 + 10%'
-'10 - 5vh + 3%'
-'-10px + 5vh, 5px - 6%'
-```
-> **NB**: If you desire to apply offsets to your poppers in a way that may make them overlap
-> with their reference element, unfortunately, you will have to disable the `flip` modifier.
-> More on this [reading this issue](https://github.com/FezVrasta/popper.js/issues/373)
+The `offset` modifier can shift your popper on both its axis.It accepts the following units:- `px` or unit-less, interpreted as pixels- `%` or `%r`, percentage relative to the length of the reference element- `%p`, percentage relative to the length of the popper element- `vw`, CSS viewport width unit- `vh`, CSS viewport height unitFor length is intended the main axis relative to the placement of the popper.<br />This means that if the placement is `top` or `bottom`, the length will be the`width`. In case of `left` or `right`, it will be the `height`.You can provide a single value (as `Number` or `String`), or a pair of valuesas `String` divided by a comma or one (or more) white spaces.<br />The latter is a deprecated method because it leads to confusion and will beremoved in v2.<br />Additionally, it accepts additions and subtractions between different units.Note that multiplications and divisions aren't supported.Valid examples are:```10'10%''10, 10''10%, 10''10 + 10%''10 - 5vh + 3%''-10px + 5vh, 5px - 6%'```> **NB**: If you desire to apply offsets to your poppers in a way that may make them overlap> with their reference element, unfortunately, you will have to disable the `flip` modifier.> You can read more on this at this [issue](https://github.com/FezVrasta/popper.js/issues/373).
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -521,18 +427,7 @@ Valid examples are:
 <a name="modifiers..preventOverflow"></a>
 
 ### modifiers~preventOverflow
-Modifier used to prevent the popper from being positioned outside the boundary.
-
-An scenario exists where the reference itself is not within the boundaries.<br />
-We can say it has "escaped the boundaries" — or just "escaped".<br />
-In this case we need to decide whether the popper should either:
-
-- detach from the reference and remain "trapped" in the boundaries, or
-- if it should ignore the boundary and "escape with its reference"
-
-When `escapeWithReference` is set to`true` and reference is completely
-outside its boundaries, the popper will overflow (or completely leave)
-the boundaries in order to remain attached to the edge of the reference.
+Modifier used to prevent the popper from being positioned outside the boundary.A scenario exists where the reference itself is not within the boundaries.<br />We can say it has "escaped the boundaries" — or just "escaped".<br />In this case we need to decide whether the popper should either:- detach from the reference and remain "trapped" in the boundaries, or- if it should ignore the boundary and "escape with its reference"When `escapeWithReference` is set to`true` and reference is completelyoutside its boundaries, the popper will overflow (or completely leave)the boundaries in order to remain attached to the edge of the reference.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -592,7 +487,7 @@ the boundaries in order to remain attached to the edge of the reference.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| padding | <code>number</code> | <code>5</code> | Amount of pixel used to define a minimum distance between the boundaries and the popper this makes sure the popper has always a little padding between the edges of its container |
+| padding | <code>number</code> | <code>5</code> | Amount of pixel used to define a minimum distance between the boundaries and the popper. This makes sure the popper always has a little padding between the edges of its container |
 
 <a name="modifiers..preventOverflow.boundariesElement"></a>
 
@@ -602,16 +497,12 @@ the boundaries in order to remain attached to the edge of the reference.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;scrollParent&#x27;</code> | Boundaries used by the modifier, can be `scrollParent`, `window`, `viewport` or any DOM element. |
+| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;scrollParent&#x27;</code> | Boundaries used by the modifier. Can be `scrollParent`, `window`, `viewport` or any DOM element. |
 
 <a name="modifiers..keepTogether"></a>
 
 ### modifiers~keepTogether
-Modifier used to make sure the reference and its popper stay near eachothers
-without leaving any gap between the two. Expecially useful when the arrow is
-enabled and you want to assure it to point to its reference element.
-It cares only about the first axis, you can still have poppers with margin
-between the popper and its reference element.
+Modifier used to make sure the reference and its popper stay near each otherwithout leaving any gap between the two. Especially useful when the arrow isenabled and you want to ensure that it points to its reference element.It cares only about the first axis. You can still have poppers with marginbetween the popper and its reference element.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -653,12 +544,7 @@ between the popper and its reference element.
 <a name="modifiers..arrow"></a>
 
 ### modifiers~arrow
-This modifier is used to move the `arrowElement` of the popper to make
-sure it is positioned between the reference element and its popper element.
-It will read the outer size of the `arrowElement` node to detect how many
-pixels of conjuction are needed.
-
-It has no effect if no `arrowElement` is provided.
+This modifier is used to move the `arrowElement` of the popper to makesure it is positioned between the reference element and its popper element.It will read the outer size of the `arrowElement` node to detect how manypixels of conjunction are needed.It has no effect if no `arrowElement` is provided.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -711,13 +597,7 @@ It has no effect if no `arrowElement` is provided.
 <a name="modifiers..flip"></a>
 
 ### modifiers~flip
-Modifier used to flip the popper's placement when it starts to overlap its
-reference element.
-
-Requires the `preventOverflow` modifier before it in order to work.
-
-**NOTE:** this modifier will interrupt the current update cycle and will
-restart it if it detects the need to flip the placement.
+Modifier used to flip the popper's placement when it starts to overlap itsreference element.Requires the `preventOverflow` modifier before it in order to work.**NOTE:** this modifier will interrupt the current update cycle and willrestart it if it detects the need to flip the placement.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -767,7 +647,7 @@ restart it if it detects the need to flip the placement.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| behavior | <code>String</code> \| <code>Array</code> | <code>&#x27;flip&#x27;</code> | The behavior used to change the popper's placement. It can be one of `flip`, `clockwise`, `counterclockwise` or an array with a list of valid placements (with optional variations). |
+| behavior | <code>String</code> \| <code>Array</code> | <code>&#x27;flip&#x27;</code> | The behavior used to change the popper's placement. It can be one of `flip`, `clockwise`, `counterclockwise` or an array with a list of valid placements (with optional variations) |
 
 <a name="modifiers..flip.padding"></a>
 
@@ -787,14 +667,12 @@ restart it if it detects the need to flip the placement.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;viewport&#x27;</code> | The element which will define the boundaries of the popper position, the popper will never be placed outside of the defined boundaries (except if keepTogether is enabled) |
+| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;viewport&#x27;</code> | The element which will define the boundaries of the popper position. The popper will never be placed outside of the defined boundaries (except if `keepTogether` is enabled) |
 
 <a name="modifiers..inner"></a>
 
 ### modifiers~inner
-Modifier used to make the popper flow toward the inner of the reference element.
-By default, when this modifier is disabled, the popper will be placed outside
-the reference element.
+Modifier used to make the popper flow toward the inner of the reference element.By default, when this modifier is disabled, the popper will be placed outsidethe reference element.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -836,12 +714,7 @@ the reference element.
 <a name="modifiers..hide"></a>
 
 ### modifiers~hide
-Modifier used to hide the popper when its reference element is outside of the
-popper boundaries. It will set a `x-out-of-boundaries` attribute which can
-be used to hide with a CSS selector the popper when its reference is
-out of boundaries.
-
-Requires the `preventOverflow` modifier before it in order to work.
+Modifier used to hide the popper when its reference element is outside of thepopper boundaries. It will set a `x-out-of-boundaries` attribute which canbe used to hide with a CSS selector the popper when its reference isout of boundaries.Requires the `preventOverflow` modifier before it in order to work.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -883,16 +756,7 @@ Requires the `preventOverflow` modifier before it in order to work.
 <a name="modifiers..computeStyle"></a>
 
 ### modifiers~computeStyle
-Computes the style that will be applied to the popper element to gets
-properly positioned.
-
-Note that this modifier will not touch the DOM, it just prepares the styles
-so that `applyStyle` modifier can apply it. This separation is useful
-in case you need to replace `applyStyle` with a custom implementation.
-
-This modifier has `850` as `order` value to maintain backward compatibility
-with previous versions of Popper.js. Expect the modifiers ordering method
-to change in future major versions of the library.
+Computes the style that will be applied to the popper element to getsproperly positioned.Note that this modifier will not touch the DOM, it just prepares the stylesso that `applyStyle` modifier can apply it. This separation is usefulin case you need to replace `applyStyle` with a custom implementation.This modifier has `850` as `order` value to maintain backward compatibilitywith previous versions of Popper.js. Expect the modifiers ordering methodto change in future major versions of the library.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -942,7 +806,7 @@ to change in future major versions of the library.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3d transformation to position the popper. Otherwise, it will use the `top` and `left` properties. |
+| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3D transformation to position the popper. Otherwise, it will use the `top` and `left` properties |
 
 <a name="modifiers..computeStyle.x"></a>
 
@@ -967,16 +831,7 @@ to change in future major versions of the library.
 <a name="modifiers..applyStyle"></a>
 
 ### modifiers~applyStyle
-Applies the computed styles to the popper element.
-
-All the DOM manipulations are limited to this modifier. This is useful in case
-you want to integrate Popper.js inside a framework or view library and you
-want to delegate all the DOM manipulations to it.
-
-Note that if you disable this modifier, you must make sure the popper element
-has its position set to `absolute` before Popper.js can do its work!
-
-Just disable this modifier and define you own to achieve the desired effect.
+Applies the computed styles to the popper element.All the DOM manipulations are limited to this modifier. This is useful in caseyou want to integrate Popper.js inside a framework or view library and youwant to delegate all the DOM manipulations to it.Note that if you disable this modifier, you must make sure the popper elementhas its position set to `absolute` before Popper.js can do its work!Just disable this modifier and define your own to achieve the desired effect.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -1037,7 +892,7 @@ Just disable this modifier and define you own to achieve the desired effect.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3d transformation to position the popper. Otherwise, it will use the `top` and `left` properties. |
+| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3D transformation to position the popper. Otherwise, it will use the `top` and `left` properties |
 
 <a name="getWindow"></a>
 
@@ -1053,10 +908,7 @@ Get the window associated with the element
 <a name="ModifierFn"></a>
 
 ## ModifierFn(data, options) ⇒ [<code>dataObject</code>](#dataObject)
-Modifier function, each modifier can have a function of this type assigned
-to its `fn` property.<br />
-These functions will be called on each update, this means that you must
-make sure they are performant enough to avoid performance bottlenecks.
+Modifier function, each modifier can have a function of this type assignedto its `fn` property.<br />These functions will be called on each update, this means that you mustmake sure they are performant enough to avoid performance bottlenecks.
 
 **Kind**: global function  
 **Returns**: [<code>dataObject</code>](#dataObject) - The data object, properly modified  

--- a/docs/_includes/popper-documentation.md
+++ b/docs/_includes/popper-documentation.md
@@ -9,8 +9,8 @@
 
 <dl>
 <dt><a href="#dataObject">dataObject</a></dt>
-<dd><p>The <code>dataObject</code> is an object containing all the information used by Popper.js.
-This object is passed to modifiers and to the <code>onCreate</code> and <code>onUpdate</code> callbacks.</p>
+<dd><p>The <code>dataObject</code> is an object containing all the informations used by Popper.js
+this object get passed to modifiers and to the <code>onCreate</code> and <code>onUpdate</code> callbacks.</p>
 </dd>
 <dt><a href="#referenceObject">referenceObject</a></dt>
 <dd><p>The <code>referenceObject</code> is an object that provides an interface compatible with Popper.js
@@ -18,7 +18,7 @@ and lets you use it as replacement of a real DOM node.<br />
 You can use this method to position a popper relatively to a set of coordinates
 in case you don&#39;t have a DOM node to use as reference.</p>
 <pre><code>new Popper(referenceObject, popperNode);
-</code></pre><p>NB: This feature isn&#39;t supported in Internet Explorer 10.</p>
+</code></pre><p>NB: This feature isn&#39;t supported in Internet Explorer 10</p>
 </dd>
 </dl>
 
@@ -82,20 +82,30 @@ make sure they are performant enough to avoid performance bottlenecks.</p>
 <a name="new_Popper_new"></a>
 
 ### new Popper(reference, popper, options)
-Creates a new Popper.js instance.
+Create a new Popper.js instance
 
 **Returns**: <code>Object</code> - instance - The generated Popper.js instance  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | reference | <code>HTMLElement</code> \| [<code>referenceObject</code>](#referenceObject) | The reference element used to position the popper |
-| popper | <code>HTMLElement</code> | The HTML element used as the popper |
+| popper | <code>HTMLElement</code> | The HTML element used as popper. |
 | options | <code>Object</code> | Your custom options to override the ones defined in [Defaults](#defaults) |
 
 <a name="Popper.Defaults"></a>
 
 ### Popper.Defaults : <code>Object</code>
-Default options provided to Popper.js constructor.<br />These can be overridden using the `options` argument of Popper.js.<br />To override an option, simply pass an object with the samestructure of the `options` object, as the 3rd argument. For example:```new Popper(ref, pop, {  modifiers: {    preventOverflow: { enabled: false }  }})```
+Default options provided to Popper.js constructor.<br />
+These can be overriden using the `options` argument of Popper.js.<br />
+To override an option, simply pass as 3rd argument an object with the same
+structure of this object, example:
+```
+new Popper(ref, pop, {
+  modifiers: {
+    preventOverflow: { enabled: false }
+  }
+})
+```
 
 **Kind**: static property of [<code>Popper</code>](#Popper)  
 
@@ -111,7 +121,7 @@ Default options provided to Popper.js constructor.<br />These can be overridden
 <a name="Popper.Defaults.placement"></a>
 
 #### Defaults.placement
-Popper's placement.
+Popper's placement
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -135,7 +145,7 @@ Set this to true if you want popper to position it self in 'fixed' mode
 <a name="Popper.Defaults.eventsEnabled"></a>
 
 #### Defaults.eventsEnabled
-Whether events (resize, scroll) are initially enabled.
+Whether events (resize, scroll) are initially enabled
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -147,7 +157,8 @@ Whether events (resize, scroll) are initially enabled.
 <a name="Popper.Defaults.removeOnDestroy"></a>
 
 #### Defaults.removeOnDestroy
-Set to true if you want to automatically remove the popper whenyou call the `destroy` method.
+Set to true if you want to automatically remove the popper when
+you call the `destroy` method.
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -159,7 +170,8 @@ Set to true if you want to automatically remove the popper whenyou call the `de
 <a name="Popper.Defaults.modifiers"></a>
 
 #### Defaults.modifiers
-List of modifiers used to modify the offsets before they are applied to the popper.They provide most of the functionalities of Popper.js.
+List of modifiers used to modify the offsets before they are applied to the popper.
+They provide most of the functionalities of Popper.js
 
 **Kind**: static property of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -171,7 +183,9 @@ List of modifiers used to modify the offsets before they are applied to the popp
 <a name="Popper.Defaults.onCreate"></a>
 
 #### Defaults.onCreate()
-Callback called when the popper is created.<br />By default, it is set to no-op.<br />Access Popper.js instance with `data.instance`.
+Callback called when the popper is created.<br />
+By default, is set to no-op.<br />
+Access Popper.js instance with `data.instance`.
 
 **Kind**: static method of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -183,7 +197,11 @@ Callback called when the popper is created.<br />By default, it is set to no-op
 <a name="Popper.Defaults.onUpdate"></a>
 
 #### Defaults.onUpdate()
-Callback called when the popper is updated. This callback is not calledon the initialization/creation of the popper, but only on subsequentupdates.<br />By default, it is set to no-op.<br />Access Popper.js instance with `data.instance`.
+Callback called when the popper is updated, this callback is not called
+on the initialization/creation of the popper, but only on subsequent
+updates.<br />
+By default, is set to no-op.<br />
+Access Popper.js instance with `data.instance`.
 
 **Kind**: static method of [<code>Defaults</code>](#Popper.Defaults)  
 **Properties**
@@ -195,44 +213,71 @@ Callback called when the popper is updated. This callback is not calledon the i
 <a name="Popper.placements"></a>
 
 ### Popper.placements : <code>enum</code>
-List of accepted placements to use as values of the `placement` option.<br />Valid placements are:- `auto`- `top`- `right`- `bottom`- `left`Each placement can have a variation from this list:- `-start`- `-end`Variations are interpreted easily if you think of them as the left to rightwritten languages. Horizontally (`top` and `bottom`), `start` is left and `end`is right.<br />Vertically (`left` and `right`), `start` is top and `end` is bottom.Some valid examples are:- `top-end` (on top of reference, right aligned)- `right-start` (on right of reference, top aligned)- `bottom` (on bottom, centered)- `auto-right` (on the side with more space available, alignment depends by placement)
+List of accepted placements to use as values of the `placement` option.<br />
+Valid placements are:
+- `auto`
+- `top`
+- `right`
+- `bottom`
+- `left`
+
+Each placement can have a variation from this list:
+- `-start`
+- `-end`
+
+Variations are interpreted easily if you think of them as the left to right
+written languages. Horizontally (`top` and `bottom`), `start` is left and `end`
+is right.<br />
+Vertically (`left` and `right`), `start` is top and `end` is bottom.
+
+Some valid examples are:
+- `top-end` (on top of reference, right aligned)
+- `right-start` (on right of reference, top aligned)
+- `bottom` (on bottom, centered)
+- `auto-right` (on the side with more space available, alignment depends by placement)
 
 **Kind**: static enum of [<code>Popper</code>](#Popper)  
 **Read only**: true  
 <a name="Popper.update"></a>
 
 ### Popper.update()
-Updates the position of the popper, computing the new offsets and applyingthe new style.<br />Prefer `scheduleUpdate` over `update` because of performance reasons.
+Updates the position of the popper, computing the new offsets and applying
+the new style.<br />
+Prefer `scheduleUpdate` over `update` because of performance reasons.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.destroy"></a>
 
 ### Popper.destroy()
-Destroys the popper.
+Destroy the popper
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.enableEventListeners"></a>
 
 ### Popper.enableEventListeners()
-It will add resize/scroll events and start recalculatingposition of the popper element when they are triggered.
+It will add resize/scroll events and start recalculating
+position of the popper element when they are triggered.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.disableEventListeners"></a>
 
 ### Popper.disableEventListeners()
-It will remove resize/scroll events and won't recalculate popper positionwhen they are triggered. It also won't trigger `onUpdate` callback anymore,unless you call `update` method manually.
+It will remove resize/scroll events and won't recalculate popper position
+when they are triggered. It also won't trigger onUpdate callback anymore,
+unless you call `update` method manually.
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="Popper.scheduleUpdate"></a>
 
 ### Popper.scheduleUpdate()
-Schedules an update. It will run on the next UI update available.
+Schedule an update, it will run on the next UI update available
 
 **Kind**: static method of [<code>Popper</code>](#Popper)  
 <a name="dataObject"></a>
 
 ## dataObject
-The `dataObject` is an object containing all the information used by Popper.js.This object is passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
+The `dataObject` is an object containing all the informations used by Popper.js
+this object get passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
 
 **Kind**: global variable  
 **Properties**
@@ -243,12 +288,12 @@ The `dataObject` is an object containing all the information used by Popper.js.
 | data.placement | <code>String</code> | Placement applied to popper |
 | data.originalPlacement | <code>String</code> | Placement originally defined on init |
 | data.flipped | <code>Boolean</code> | True if popper has been flipped by flip modifier |
-| data.hide | <code>Boolean</code> | True if the reference element is out of boundaries, useful to know when to hide the popper |
+| data.hide | <code>Boolean</code> | True if the reference element is out of boundaries, useful to know when to hide the popper. |
 | data.arrowElement | <code>HTMLElement</code> | Node used as arrow by arrow modifier |
-| data.styles | <code>Object</code> | Any CSS property defined here will be applied to the popper. It expects the JavaScript nomenclature (eg. `marginBottom`) |
-| data.arrowStyles | <code>Object</code> | Any CSS property defined here will be applied to the popper arrow. It expects the JavaScript nomenclature (eg. `marginBottom`) |
+| data.styles | <code>Object</code> | Any CSS property defined here will be applied to the popper, it expects the JavaScript nomenclature (eg. `marginBottom`) |
+| data.arrowStyles | <code>Object</code> | Any CSS property defined here will be applied to the popper arrow, it expects the JavaScript nomenclature (eg. `marginBottom`) |
 | data.boundaries | <code>Object</code> | Offsets of the popper boundaries |
-| data.offsets | <code>Object</code> | The measurements of popper, reference and arrow elements |
+| data.offsets | <code>Object</code> | The measurements of popper, reference and arrow elements. |
 | data.offsets.popper | <code>Object</code> | `top`, `left`, `width`, `height` values |
 | data.offsets.reference | <code>Object</code> | `top`, `left`, `width`, `height` values |
 | data.offsets.arrow | <code>Object</code> | `top` and `left` offsets, only one of them will be different from 0 |
@@ -256,7 +301,16 @@ The `dataObject` is an object containing all the information used by Popper.js.
 <a name="referenceObject"></a>
 
 ## referenceObject
-The `referenceObject` is an object that provides an interface compatible with Popper.jsand lets you use it as replacement of a real DOM node.<br />You can use this method to position a popper relatively to a set of coordinatesin case you don't have a DOM node to use as reference.```new Popper(referenceObject, popperNode);```NB: This feature isn't supported in Internet Explorer 10.
+The `referenceObject` is an object that provides an interface compatible with Popper.js
+and lets you use it as replacement of a real DOM node.<br />
+You can use this method to position a popper relatively to a set of coordinates
+in case you don't have a DOM node to use as reference.
+
+```
+new Popper(referenceObject, popperNode);
+```
+
+NB: This feature isn't supported in Internet Explorer 10
 
 **Kind**: global variable  
 **Properties**
@@ -270,7 +324,12 @@ The `referenceObject` is an object that provides an interface compatible with Po
 <a name="modifiers"></a>
 
 ## modifiers : <code>object</code>
-Modifiers are plugins used to alter the behavior of your poppers.<br />Popper.js uses a set of 9 modifiers to provide all the basic functionalitiesneeded by the library.Usually you don't want to override the `order`, `fn` and `onLoad` props.All the other properties are configurations that could be tweaked.
+Modifiers are plugins used to alter the behavior of your poppers.<br />
+Popper.js uses a set of 9 modifiers to provide all the basic functionalities
+needed by the library.
+
+Usually you don't want to override the `order`, `fn` and `onLoad` props.
+All the other properties are configurations that could be tweaked.
 
 **Kind**: global namespace  
 
@@ -332,7 +391,10 @@ Modifiers are plugins used to alter the behavior of your poppers.<br />Popper.j
 <a name="modifiers..shift"></a>
 
 ### modifiers~shift
-Modifier used to shift the popper on the start or end of its referenceelement.<br />It will read the variation of the `placement` property.<br />It can be one either `-end` or `-start`.
+Modifier used to shift the popper on the start or end of its reference
+element.<br />
+It will read the variation of the `placement` property.<br />
+It can be one either `-end` or `-start`.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -374,7 +436,39 @@ Modifier used to shift the popper on the start or end of its referenceelement.<
 <a name="modifiers..offset"></a>
 
 ### modifiers~offset
-The `offset` modifier can shift your popper on both its axis.It accepts the following units:- `px` or unit-less, interpreted as pixels- `%` or `%r`, percentage relative to the length of the reference element- `%p`, percentage relative to the length of the popper element- `vw`, CSS viewport width unit- `vh`, CSS viewport height unitFor length is intended the main axis relative to the placement of the popper.<br />This means that if the placement is `top` or `bottom`, the length will be the`width`. In case of `left` or `right`, it will be the `height`.You can provide a single value (as `Number` or `String`), or a pair of valuesas `String` divided by a comma or one (or more) white spaces.<br />The latter is a deprecated method because it leads to confusion and will beremoved in v2.<br />Additionally, it accepts additions and subtractions between different units.Note that multiplications and divisions aren't supported.Valid examples are:```10'10%''10, 10''10%, 10''10 + 10%''10 - 5vh + 3%''-10px + 5vh, 5px - 6%'```> **NB**: If you desire to apply offsets to your poppers in a way that may make them overlap> with their reference element, unfortunately, you will have to disable the `flip` modifier.> You can read more on this at this [issue](https://github.com/FezVrasta/popper.js/issues/373).
+The `offset` modifier can shift your popper on both its axis.
+
+It accepts the following units:
+- `px` or unitless, interpreted as pixels
+- `%` or `%r`, percentage relative to the length of the reference element
+- `%p`, percentage relative to the length of the popper element
+- `vw`, CSS viewport width unit
+- `vh`, CSS viewport height unit
+
+For length is intended the main axis relative to the placement of the popper.<br />
+This means that if the placement is `top` or `bottom`, the length will be the
+`width`. In case of `left` or `right`, it will be the height.
+
+You can provide a single value (as `Number` or `String`), or a pair of values
+as `String` divided by a comma or one (or more) white spaces.<br />
+The latter is a deprecated method because it leads to confusion and will be
+removed in v2.<br />
+Additionally, it accepts additions and subtractions between different units.
+Note that multiplications and divisions aren't supported.
+
+Valid examples are:
+```
+10
+'10%'
+'10, 10'
+'10%, 10'
+'10 + 10%'
+'10 - 5vh + 3%'
+'-10px + 5vh, 5px - 6%'
+```
+> **NB**: If you desire to apply offsets to your poppers in a way that may make them overlap
+> with their reference element, unfortunately, you will have to disable the `flip` modifier.
+> More on this [reading this issue](https://github.com/FezVrasta/popper.js/issues/373)
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -427,7 +521,18 @@ The `offset` modifier can shift your popper on both its axis.It accepts the fo
 <a name="modifiers..preventOverflow"></a>
 
 ### modifiers~preventOverflow
-Modifier used to prevent the popper from being positioned outside the boundary.A scenario exists where the reference itself is not within the boundaries.<br />We can say it has "escaped the boundaries" — or just "escaped".<br />In this case we need to decide whether the popper should either:- detach from the reference and remain "trapped" in the boundaries, or- if it should ignore the boundary and "escape with its reference"When `escapeWithReference` is set to`true` and reference is completelyoutside its boundaries, the popper will overflow (or completely leave)the boundaries in order to remain attached to the edge of the reference.
+Modifier used to prevent the popper from being positioned outside the boundary.
+
+An scenario exists where the reference itself is not within the boundaries.<br />
+We can say it has "escaped the boundaries" — or just "escaped".<br />
+In this case we need to decide whether the popper should either:
+
+- detach from the reference and remain "trapped" in the boundaries, or
+- if it should ignore the boundary and "escape with its reference"
+
+When `escapeWithReference` is set to`true` and reference is completely
+outside its boundaries, the popper will overflow (or completely leave)
+the boundaries in order to remain attached to the edge of the reference.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -487,7 +592,7 @@ Modifier used to prevent the popper from being positioned outside the boundary.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| padding | <code>number</code> | <code>5</code> | Amount of pixel used to define a minimum distance between the boundaries and the popper. This makes sure the popper always has a little padding between the edges of its container |
+| padding | <code>number</code> | <code>5</code> | Amount of pixel used to define a minimum distance between the boundaries and the popper this makes sure the popper has always a little padding between the edges of its container |
 
 <a name="modifiers..preventOverflow.boundariesElement"></a>
 
@@ -497,12 +602,16 @@ Modifier used to prevent the popper from being positioned outside the boundary.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;scrollParent&#x27;</code> | Boundaries used by the modifier. Can be `scrollParent`, `window`, `viewport` or any DOM element. |
+| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;scrollParent&#x27;</code> | Boundaries used by the modifier, can be `scrollParent`, `window`, `viewport` or any DOM element. |
 
 <a name="modifiers..keepTogether"></a>
 
 ### modifiers~keepTogether
-Modifier used to make sure the reference and its popper stay near each otherwithout leaving any gap between the two. Especially useful when the arrow isenabled and you want to ensure that it points to its reference element.It cares only about the first axis. You can still have poppers with marginbetween the popper and its reference element.
+Modifier used to make sure the reference and its popper stay near eachothers
+without leaving any gap between the two. Expecially useful when the arrow is
+enabled and you want to assure it to point to its reference element.
+It cares only about the first axis, you can still have poppers with margin
+between the popper and its reference element.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -544,7 +653,12 @@ Modifier used to make sure the reference and its popper stay near each otherwit
 <a name="modifiers..arrow"></a>
 
 ### modifiers~arrow
-This modifier is used to move the `arrowElement` of the popper to makesure it is positioned between the reference element and its popper element.It will read the outer size of the `arrowElement` node to detect how manypixels of conjunction are needed.It has no effect if no `arrowElement` is provided.
+This modifier is used to move the `arrowElement` of the popper to make
+sure it is positioned between the reference element and its popper element.
+It will read the outer size of the `arrowElement` node to detect how many
+pixels of conjuction are needed.
+
+It has no effect if no `arrowElement` is provided.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -597,7 +711,13 @@ This modifier is used to move the `arrowElement` of the popper to makesure it i
 <a name="modifiers..flip"></a>
 
 ### modifiers~flip
-Modifier used to flip the popper's placement when it starts to overlap itsreference element.Requires the `preventOverflow` modifier before it in order to work.**NOTE:** this modifier will interrupt the current update cycle and willrestart it if it detects the need to flip the placement.
+Modifier used to flip the popper's placement when it starts to overlap its
+reference element.
+
+Requires the `preventOverflow` modifier before it in order to work.
+
+**NOTE:** this modifier will interrupt the current update cycle and will
+restart it if it detects the need to flip the placement.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -647,7 +767,7 @@ Modifier used to flip the popper's placement when it starts to overlap itsrefer
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| behavior | <code>String</code> \| <code>Array</code> | <code>&#x27;flip&#x27;</code> | The behavior used to change the popper's placement. It can be one of `flip`, `clockwise`, `counterclockwise` or an array with a list of valid placements (with optional variations) |
+| behavior | <code>String</code> \| <code>Array</code> | <code>&#x27;flip&#x27;</code> | The behavior used to change the popper's placement. It can be one of `flip`, `clockwise`, `counterclockwise` or an array with a list of valid placements (with optional variations). |
 
 <a name="modifiers..flip.padding"></a>
 
@@ -667,12 +787,14 @@ Modifier used to flip the popper's placement when it starts to overlap itsrefer
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;viewport&#x27;</code> | The element which will define the boundaries of the popper position. The popper will never be placed outside of the defined boundaries (except if `keepTogether` is enabled) |
+| boundariesElement | <code>String</code> \| <code>HTMLElement</code> | <code>&#x27;viewport&#x27;</code> | The element which will define the boundaries of the popper position, the popper will never be placed outside of the defined boundaries (except if keepTogether is enabled) |
 
 <a name="modifiers..inner"></a>
 
 ### modifiers~inner
-Modifier used to make the popper flow toward the inner of the reference element.By default, when this modifier is disabled, the popper will be placed outsidethe reference element.
+Modifier used to make the popper flow toward the inner of the reference element.
+By default, when this modifier is disabled, the popper will be placed outside
+the reference element.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -714,7 +836,12 @@ Modifier used to make the popper flow toward the inner of the reference element.
 <a name="modifiers..hide"></a>
 
 ### modifiers~hide
-Modifier used to hide the popper when its reference element is outside of thepopper boundaries. It will set a `x-out-of-boundaries` attribute which canbe used to hide with a CSS selector the popper when its reference isout of boundaries.Requires the `preventOverflow` modifier before it in order to work.
+Modifier used to hide the popper when its reference element is outside of the
+popper boundaries. It will set a `x-out-of-boundaries` attribute which can
+be used to hide with a CSS selector the popper when its reference is
+out of boundaries.
+
+Requires the `preventOverflow` modifier before it in order to work.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -756,7 +883,16 @@ Modifier used to hide the popper when its reference element is outside of thepo
 <a name="modifiers..computeStyle"></a>
 
 ### modifiers~computeStyle
-Computes the style that will be applied to the popper element to getsproperly positioned.Note that this modifier will not touch the DOM, it just prepares the stylesso that `applyStyle` modifier can apply it. This separation is usefulin case you need to replace `applyStyle` with a custom implementation.This modifier has `850` as `order` value to maintain backward compatibilitywith previous versions of Popper.js. Expect the modifiers ordering methodto change in future major versions of the library.
+Computes the style that will be applied to the popper element to gets
+properly positioned.
+
+Note that this modifier will not touch the DOM, it just prepares the styles
+so that `applyStyle` modifier can apply it. This separation is useful
+in case you need to replace `applyStyle` with a custom implementation.
+
+This modifier has `850` as `order` value to maintain backward compatibility
+with previous versions of Popper.js. Expect the modifiers ordering method
+to change in future major versions of the library.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -806,7 +942,7 @@ Computes the style that will be applied to the popper element to getsproperly p
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3D transformation to position the popper. Otherwise, it will use the `top` and `left` properties |
+| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3d transformation to position the popper. Otherwise, it will use the `top` and `left` properties. |
 
 <a name="modifiers..computeStyle.x"></a>
 
@@ -831,7 +967,16 @@ Computes the style that will be applied to the popper element to getsproperly p
 <a name="modifiers..applyStyle"></a>
 
 ### modifiers~applyStyle
-Applies the computed styles to the popper element.All the DOM manipulations are limited to this modifier. This is useful in caseyou want to integrate Popper.js inside a framework or view library and youwant to delegate all the DOM manipulations to it.Note that if you disable this modifier, you must make sure the popper elementhas its position set to `absolute` before Popper.js can do its work!Just disable this modifier and define your own to achieve the desired effect.
+Applies the computed styles to the popper element.
+
+All the DOM manipulations are limited to this modifier. This is useful in case
+you want to integrate Popper.js inside a framework or view library and you
+want to delegate all the DOM manipulations to it.
+
+Note that if you disable this modifier, you must make sure the popper element
+has its position set to `absolute` before Popper.js can do its work!
+
+Just disable this modifier and define you own to achieve the desired effect.
 
 **Kind**: inner property of [<code>modifiers</code>](#modifiers)  
 
@@ -892,7 +1037,7 @@ Applies the computed styles to the popper element.All the DOM manipulations ar
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3D transformation to position the popper. Otherwise, it will use the `top` and `left` properties |
+| gpuAcceleration | <code>Boolean</code> | <code>true</code> | If true, it uses the CSS 3d transformation to position the popper. Otherwise, it will use the `top` and `left` properties. |
 
 <a name="getWindow"></a>
 
@@ -908,7 +1053,10 @@ Get the window associated with the element
 <a name="ModifierFn"></a>
 
 ## ModifierFn(data, options) ⇒ [<code>dataObject</code>](#dataObject)
-Modifier function, each modifier can have a function of this type assignedto its `fn` property.<br />These functions will be called on each update, this means that you mustmake sure they are performant enough to avoid performance bottlenecks.
+Modifier function, each modifier can have a function of this type assigned
+to its `fn` property.<br />
+These functions will be called on each update, this means that you must
+make sure they are performant enough to avoid performance bottlenecks.
 
 **Kind**: global function  
 **Returns**: [<code>dataObject</code>](#dataObject) - The data object, properly modified  

--- a/packages/popper/src/index.js
+++ b/packages/popper/src/index.js
@@ -12,10 +12,10 @@ import placements from './methods/placements';
 
 export default class Popper {
   /**
-   * Create a new Popper.js instance
+   * Creates a new Popper.js instance.
    * @class Popper
    * @param {HTMLElement|referenceObject} reference - The reference element used to position the popper
-   * @param {HTMLElement} popper - The HTML element used as popper.
+   * @param {HTMLElement} popper - The HTML element used as the popper
    * @param {Object} options - Your custom options to override the ones defined in [Defaults](#defaults)
    * @return {Object} instance - The generated Popper.js instance
    */
@@ -104,7 +104,7 @@ export default class Popper {
   }
 
   /**
-   * Schedule an update, it will run on the next UI update available
+   * Schedules an update. It will run on the next UI update available.
    * @method scheduleUpdate
    * @memberof Popper
    */
@@ -143,7 +143,7 @@ export default class Popper {
  * new Popper(referenceObject, popperNode);
  * ```
  *
- * NB: This feature isn't supported in Internet Explorer 10
+ * NB: This feature isn't supported in Internet Explorer 10.
  * @name referenceObject
  * @property {Function} data.getBoundingClientRect
  * A function that returns a set of coordinates compatible with the native `getBoundingClientRect` method.

--- a/packages/popper/src/methods/defaults.js
+++ b/packages/popper/src/methods/defaults.js
@@ -2,9 +2,9 @@ import modifiers from '../modifiers/index';
 
 /**
  * Default options provided to Popper.js constructor.<br />
- * These can be overriden using the `options` argument of Popper.js.<br />
- * To override an option, simply pass as 3rd argument an object with the same
- * structure of this object, example:
+ * These can be overridden using the `options` argument of Popper.js.<br />
+ * To override an option, simply pass an object with the same
+ * structure of the `options` object, as the 3rd argument. For example:
  * ```
  * new Popper(ref, pop, {
  *   modifiers: {
@@ -18,7 +18,7 @@ import modifiers from '../modifiers/index';
  */
 export default {
   /**
-   * Popper's placement
+   * Popper's placement.
    * @prop {Popper.placements} placement='bottom'
    */
   placement: 'bottom',
@@ -30,7 +30,7 @@ export default {
   positionFixed: false,
 
   /**
-   * Whether events (resize, scroll) are initially enabled
+   * Whether events (resize, scroll) are initially enabled.
    * @prop {Boolean} eventsEnabled=true
    */
   eventsEnabled: true,
@@ -44,17 +44,17 @@ export default {
 
   /**
    * Callback called when the popper is created.<br />
-   * By default, is set to no-op.<br />
+   * By default, it is set to no-op.<br />
    * Access Popper.js instance with `data.instance`.
    * @prop {onCreate}
    */
   onCreate: () => {},
 
   /**
-   * Callback called when the popper is updated, this callback is not called
+   * Callback called when the popper is updated. This callback is not called
    * on the initialization/creation of the popper, but only on subsequent
    * updates.<br />
-   * By default, is set to no-op.<br />
+   * By default, it is set to no-op.<br />
    * Access Popper.js instance with `data.instance`.
    * @prop {onUpdate}
    */
@@ -62,7 +62,7 @@ export default {
 
   /**
    * List of modifiers used to modify the offsets before they are applied to the popper.
-   * They provide most of the functionalities of Popper.js
+   * They provide most of the functionalities of Popper.js.
    * @prop {modifiers}
    */
   modifiers,

--- a/packages/popper/src/methods/destroy.js
+++ b/packages/popper/src/methods/destroy.js
@@ -2,7 +2,7 @@ import isModifierEnabled from '../utils/isModifierEnabled';
 import getSupportedPropertyName from '../utils/getSupportedPropertyName';
 
 /**
- * Destroy the popper
+ * Destroys the popper.
  * @method
  * @memberof Popper
  */

--- a/packages/popper/src/methods/disableEventListeners.js
+++ b/packages/popper/src/methods/disableEventListeners.js
@@ -2,7 +2,7 @@ import removeEventListeners from '../utils/removeEventListeners';
 
 /**
  * It will remove resize/scroll events and won't recalculate popper position
- * when they are triggered. It also won't trigger onUpdate callback anymore,
+ * when they are triggered. It also won't trigger `onUpdate` callback anymore,
  * unless you call `update` method manually.
  * @method
  * @memberof Popper

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -50,7 +50,7 @@ export default function arrow(data, options) {
 
   //
   // extends keepTogether behavior making sure the popper and its
-  // reference have enough pixels in conjuction
+  // reference have enough pixels in conjunction
   //
 
   // top/left side

--- a/packages/popper/src/modifiers/index.js
+++ b/packages/popper/src/modifiers/index.js
@@ -52,7 +52,7 @@ export default {
    * The `offset` modifier can shift your popper on both its axis.
    *
    * It accepts the following units:
-   * - `px` or unitless, interpreted as pixels
+   * - `px` or unit-less, interpreted as pixels
    * - `%` or `%r`, percentage relative to the length of the reference element
    * - `%p`, percentage relative to the length of the popper element
    * - `vw`, CSS viewport width unit
@@ -60,7 +60,7 @@ export default {
    *
    * For length is intended the main axis relative to the placement of the popper.<br />
    * This means that if the placement is `top` or `bottom`, the length will be the
-   * `width`. In case of `left` or `right`, it will be the height.
+   * `width`. In case of `left` or `right`, it will be the `height`.
    *
    * You can provide a single value (as `Number` or `String`), or a pair of values
    * as `String` divided by a comma or one (or more) white spaces.<br />
@@ -81,7 +81,7 @@ export default {
    * ```
    * > **NB**: If you desire to apply offsets to your poppers in a way that may make them overlap
    * > with their reference element, unfortunately, you will have to disable the `flip` modifier.
-   * > More on this [reading this issue](https://github.com/FezVrasta/popper.js/issues/373)
+   * > You can read more on this at this [issue](https://github.com/FezVrasta/popper.js/issues/373).
    *
    * @memberof modifiers
    * @inner
@@ -102,7 +102,7 @@ export default {
   /**
    * Modifier used to prevent the popper from being positioned outside the boundary.
    *
-   * An scenario exists where the reference itself is not within the boundaries.<br />
+   * A scenario exists where the reference itself is not within the boundaries.<br />
    * We can say it has "escaped the boundaries" — or just "escaped".<br />
    * In this case we need to decide whether the popper should either:
    *
@@ -132,23 +132,23 @@ export default {
     /**
      * @prop {number} padding=5
      * Amount of pixel used to define a minimum distance between the boundaries
-     * and the popper this makes sure the popper has always a little padding
+     * and the popper. This makes sure the popper always has a little padding
      * between the edges of its container
      */
     padding: 5,
     /**
      * @prop {String|HTMLElement} boundariesElement='scrollParent'
-     * Boundaries used by the modifier, can be `scrollParent`, `window`,
+     * Boundaries used by the modifier. Can be `scrollParent`, `window`,
      * `viewport` or any DOM element.
      */
     boundariesElement: 'scrollParent',
   },
 
   /**
-   * Modifier used to make sure the reference and its popper stay near eachothers
-   * without leaving any gap between the two. Expecially useful when the arrow is
-   * enabled and you want to assure it to point to its reference element.
-   * It cares only about the first axis, you can still have poppers with margin
+   * Modifier used to make sure the reference and its popper stay near each other
+   * without leaving any gap between the two. Especially useful when the arrow is
+   * enabled and you want to ensure that it points to its reference element.
+   * It cares only about the first axis. You can still have poppers with margin
    * between the popper and its reference element.
    * @memberof modifiers
    * @inner
@@ -166,7 +166,7 @@ export default {
    * This modifier is used to move the `arrowElement` of the popper to make
    * sure it is positioned between the reference element and its popper element.
    * It will read the outer size of the `arrowElement` node to detect how many
-   * pixels of conjuction are needed.
+   * pixels of conjunction are needed.
    *
    * It has no effect if no `arrowElement` is provided.
    * @memberof modifiers
@@ -205,7 +205,7 @@ export default {
      * @prop {String|Array} behavior='flip'
      * The behavior used to change the popper's placement. It can be one of
      * `flip`, `clockwise`, `counterclockwise` or an array with a list of valid
-     * placements (with optional variations).
+     * placements (with optional variations)
      */
     behavior: 'flip',
     /**
@@ -215,9 +215,9 @@ export default {
     padding: 5,
     /**
      * @prop {String|HTMLElement} boundariesElement='viewport'
-     * The element which will define the boundaries of the popper position,
-     * the popper will never be placed outside of the defined boundaries
-     * (except if keepTogether is enabled)
+     * The element which will define the boundaries of the popper position.
+     * The popper will never be placed outside of the defined boundaries
+     * (except if `keepTogether` is enabled)
      */
     boundariesElement: 'viewport',
   },
@@ -281,8 +281,8 @@ export default {
     fn: computeStyle,
     /**
      * @prop {Boolean} gpuAcceleration=true
-     * If true, it uses the CSS 3d transformation to position the popper.
-     * Otherwise, it will use the `top` and `left` properties.
+     * If true, it uses the CSS 3D transformation to position the popper.
+     * Otherwise, it will use the `top` and `left` properties
      */
     gpuAcceleration: true,
     /**
@@ -309,7 +309,7 @@ export default {
    * Note that if you disable this modifier, you must make sure the popper element
    * has its position set to `absolute` before Popper.js can do its work!
    *
-   * Just disable this modifier and define you own to achieve the desired effect.
+   * Just disable this modifier and define your own to achieve the desired effect.
    *
    * @memberof modifiers
    * @inner
@@ -326,27 +326,27 @@ export default {
     /**
      * @deprecated since version 1.10.0, the property moved to `computeStyle` modifier
      * @prop {Boolean} gpuAcceleration=true
-     * If true, it uses the CSS 3d transformation to position the popper.
-     * Otherwise, it will use the `top` and `left` properties.
+     * If true, it uses the CSS 3D transformation to position the popper.
+     * Otherwise, it will use the `top` and `left` properties
      */
     gpuAcceleration: undefined,
   },
 };
 
 /**
- * The `dataObject` is an object containing all the informations used by Popper.js
- * this object get passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
+ * The `dataObject` is an object containing all the information used by Popper.js.
+ * This object is passed to modifiers and to the `onCreate` and `onUpdate` callbacks.
  * @name dataObject
  * @property {Object} data.instance The Popper.js instance
  * @property {String} data.placement Placement applied to popper
  * @property {String} data.originalPlacement Placement originally defined on init
  * @property {Boolean} data.flipped True if popper has been flipped by flip modifier
- * @property {Boolean} data.hide True if the reference element is out of boundaries, useful to know when to hide the popper.
+ * @property {Boolean} data.hide True if the reference element is out of boundaries, useful to know when to hide the popper
  * @property {HTMLElement} data.arrowElement Node used as arrow by arrow modifier
- * @property {Object} data.styles Any CSS property defined here will be applied to the popper, it expects the JavaScript nomenclature (eg. `marginBottom`)
- * @property {Object} data.arrowStyles Any CSS property defined here will be applied to the popper arrow, it expects the JavaScript nomenclature (eg. `marginBottom`)
+ * @property {Object} data.styles Any CSS property defined here will be applied to the popper. It expects the JavaScript nomenclature (eg. `marginBottom`)
+ * @property {Object} data.arrowStyles Any CSS property defined here will be applied to the popper arrow. It expects the JavaScript nomenclature (eg. `marginBottom`)
  * @property {Object} data.boundaries Offsets of the popper boundaries
- * @property {Object} data.offsets The measurements of popper, reference and arrow elements.
+ * @property {Object} data.offsets The measurements of popper, reference and arrow elements
  * @property {Object} data.offsets.popper `top`, `left`, `width`, `height` values
  * @property {Object} data.offsets.reference `top`, `left`, `width`, `height` values
  * @property {Object} data.offsets.arrow] `top` and `left` offsets, only one of them will be different from 0


### PR DESCRIPTION
Hi!

Thanks for making this awesome library. 🎉 I noticed that there were a few typos and grammatical errors in the Popper docs. Also, I noticed that the docs are generated from the JSDocs. For now, I've edited the `.md` file directly in order to get your feedback. Once you're OK with the changes, I'll change the source files.

Things I've done:

1. Corrected typos
1. Highlighted some strings as `code` as they're referring to actual code
1. Split some sentences into two to make them grammatically correct
1. Normalized the placement of `.`s in the docs
    1. No `.`s in the doc tables
    1.  `.`s at the end of API descriptions 