### PR TITLE
html.topScroll -> body.topScroll  to support safari top scroll issue

### DIFF
--- a/packages/popper/src/utils/getScroll.js
+++ b/packages/popper/src/utils/getScroll.js
@@ -11,7 +11,7 @@ export default function getScroll(element, side = 'top') {
   const nodeName = element.nodeName;
 
   if (nodeName === 'BODY' || nodeName === 'HTML') {
-    const html = element.ownerDocument.documentElement;
+    const html = element.ownerDocument.body;
     const scrollingElement = element.ownerDocument.scrollingElement || html;
     return scrollingElement[upperSide];
   }


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
Hi, 
I faced with bug when i used Safari. I saw the popper's vertical boundaries was between 0px to 100vh.
I found that in Safari document.documentElement.scrollTop = 0, so i replaced it with the body at getScroll function.
The bug also happened in any preventOverflow.boundariesElement when the target element is lower the 
then the viewport.

here is an example I wrote (:
https://codepen.io/anon/pen/EEvELV

