### PR TITLE
Fix rounding

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -37,7 +37,9 @@ export default function computeStyle(data, options) {
     position: popper.position,
   };
 
-  // round sides to avoid blurry text
+  // Avoid blurry text by using full pixel integers.
+  // For pixel-perfect positioning, top/bottom prefers rounded
+  // values, while left/right prefers floored values.
   const offsets = {
     left: Math.floor(popper.left),
     top: Math.round(popper.top),

--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -37,14 +37,12 @@ export default function computeStyle(data, options) {
     position: popper.position,
   };
 
-  // floor sides to avoid blurry text
-  // no need to floor if not using gpuAcceleration
-  const floor = gpuAcceleration ? Math.floor : v => v;
+  // round sides to avoid blurry text
   const offsets = {
-    left: floor(popper.left),
-    top: floor(popper.top),
-    bottom: floor(popper.bottom),
-    right: floor(popper.right),
+    left: Math.floor(popper.left),
+    top: Math.round(popper.top),
+    bottom: Math.round(popper.bottom),
+    right: Math.floor(popper.right),
   };
 
   const sideA = x === 'bottom' ? 'top' : 'bottom';

--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -38,11 +38,13 @@ export default function computeStyle(data, options) {
   };
 
   // floor sides to avoid blurry text
+  // no need to floor if not using gpuAcceleration
+  const floor = gpuAcceleration ? Math.floor : v => v;
   const offsets = {
-    left: Math.floor(popper.left),
-    top: Math.floor(popper.top),
-    bottom: Math.floor(popper.bottom),
-    right: Math.floor(popper.right),
+    left: floor(popper.left),
+    top: floor(popper.top),
+    bottom: floor(popper.bottom),
+    right: floor(popper.right),
   };
 
   const sideA = x === 'bottom' ? 'top' : 'bottom';


### PR DESCRIPTION
As mentioned in #551, this will allow for "pixel-perfect" positioning if desired, since subpixel `top/left` positioning doesn't cause blurriness unlike `translate3d`.