### PR TITLE
fix #251 (finally)

### DIFF
--- a/packages/popper/src/methods/update.js
+++ b/packages/popper/src/methods/update.js
@@ -29,11 +29,10 @@ export default function update() {
   // NOTE: DOM access here
   // resets the popper's position so that the document size can be calculated excluding
   // the size of the popper element itself
-  Object.assign(this.popper.style, {
-    top: '',
-    left: '',
-    [getSupportedPropertyName('transform')]: '',
-  });
+  const popperStyles = this.popper.style;
+  popperStyles.top = '';
+  popperStyles.left = '';
+  popperStyles[getSupportedPropertyName('transform')] = '';
 
   // compute reference element offsets
   data.offsets.reference = getReferenceOffsets(

--- a/packages/popper/src/methods/update.js
+++ b/packages/popper/src/methods/update.js
@@ -2,6 +2,7 @@ import computeAutoPlacement from '../utils/computeAutoPlacement';
 import getReferenceOffsets from '../utils/getReferenceOffsets';
 import getPopperOffsets from '../utils/getPopperOffsets';
 import runModifiers from '../utils/runModifiers';
+import getSupportedPropertyName from '../utils/getSupportedPropertyName';
 
 /**
  * Updates the position of the popper, computing the new offsets and applying
@@ -24,6 +25,15 @@ export default function update() {
     flipped: false,
     offsets: {},
   };
+
+  // NOTE: DOM access here
+  // resets the popper's position so that the document size can be calculated excluding
+  // the size of the popper element itself
+  Object.assign(this.popper.style, {
+    top: '',
+    left: '',
+    [getSupportedPropertyName('transform')]: '',
+  });
 
   // compute reference element offsets
   data.offsets.reference = getReferenceOffsets(


### PR DESCRIPTION
#251 has been left open too long I think, and this is the solution that @kybishop suggested, and the one I use personally, but it should be placed in `update()` so it works for resizing too.

Yes, it accesses the DOM and will reduce performance, but I don't think there's another way.  Please test the performance difference before/after to see.

`Object.assign()` is being used, which I believe is already being ponyfilled in the lib.