### PR TITLE
feat: Get elements ownerDocument for correct measurements

### DIFF
--- a/packages/popper/src/utils/getBoundaries.js
+++ b/packages/popper/src/utils/getBoundaries.js
@@ -57,7 +57,7 @@ export default function getBoundaries(
 
     // In case of HTML, we need a different computation
     if (boundariesNode.nodeName === 'HTML' && !isFixed(offsetParent)) {
-      const { height, width } = getWindowSizes();
+      const { height, width } = getWindowSizes(popper.ownerDocument);
       boundaries.top += offsets.top - offsets.marginTop;
       boundaries.bottom = height + offsets.top;
       boundaries.left += offsets.left - offsets.marginLeft;

--- a/packages/popper/src/utils/getBoundingClientRect.js
+++ b/packages/popper/src/utils/getBoundingClientRect.js
@@ -42,7 +42,7 @@ export default function getBoundingClientRect(element) {
   };
 
   // subtract scrollbar size from sizes
-  const sizes = element.nodeName === 'HTML' ? getWindowSizes() : {};
+  const sizes = element.nodeName === 'HTML' ? getWindowSizes(element.ownerDocument) : {};
   const width =
     sizes.width || element.clientWidth || result.right - result.left;
   const height =

--- a/packages/popper/src/utils/getOffsetRect.js
+++ b/packages/popper/src/utils/getOffsetRect.js
@@ -11,7 +11,7 @@ import getClientRect from './getClientRect';
 export default function getOffsetRect(element) {
   let elementRect;
   if (element.nodeName === 'HTML') {
-    const { width, height } = getWindowSizes();
+    const { width, height } = getWindowSizes(element.ownerDocument);
     elementRect = {
       width,
       height,

--- a/packages/popper/src/utils/getWindowSizes.js
+++ b/packages/popper/src/utils/getWindowSizes.js
@@ -15,7 +15,7 @@ function getSize(axis, body, html, computedStyle) {
   );
 }
 
-export default function getWindowSizes() {
+export default function getWindowSizes(document) {
   const body = document.body;
   const html = document.documentElement;
   const computedStyle = isIE(10) && getComputedStyle(html);


### PR DESCRIPTION
After some digging I found that when `getWindowSizes` is called it looks at the parent document which get incorrect values when using this inside of an iframe.

I created a test case here: https://codesandbox.io/s/8n31m5132j

First one is in an iframe and always puts it at the bottom even though it doesn't have enough room.

The second one shows the same thing but not wrapped in a iframe. This correctly moved the popper to the top of the element and upon scrolling moves it to the bottom.