### PR TITLE
fix(computeStyle): correctly calculate `bottom` when x="top" and `rig…

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -66,12 +66,22 @@ export default function computeStyle(data, options) {
   // its bottom.
   let left, top;
   if (sideA === 'bottom') {
-    top = -offsetParentRect.height + offsets.bottom;
+    // when offsetParent is <html> the positioning is relative to the bottom of the screen (excluding the scrollbar)
+    // and not the bottom of the html element
+    if (offsetParent.nodeName === 'HTML') {
+      top = -offsetParent.clientHeight + offsets.bottom;
+    } else {
+      top = -offsetParentRect.height + offsets.bottom;
+    }
   } else {
     top = offsets.top;
   }
   if (sideB === 'right') {
-    left = -offsetParentRect.width + offsets.right;
+    if (offsetParent.nodeName === 'HTML') {
+      left = -offsetParent.clientWidth + offsets.right;
+    } else {
+      left = -offsetParentRect.width + offsets.right;
+    }
   } else {
     left = offsets.left;
   }

--- a/packages/popper/tests/functional/computeStyle.js
+++ b/packages/popper/tests/functional/computeStyle.js
@@ -1,0 +1,68 @@
+import Popper from '../../src/index.js';
+
+import '@popperjs/test-utils';
+const jasmineWrapper = document.getElementById('jasmineWrapper');
+const arrowSize = 5;
+
+// Utils
+import appendNewPopper from '@popperjs/test-utils/utils/appendNewPopper';
+import appendNewRef from '@popperjs/test-utils/utils/appendNewRef';
+import getRect from '../utils/getRect';
+
+[true, false].forEach((positionFixed) => {
+  beforeEach(function(){
+    Popper.Defaults.positionFixed = positionFixed;
+  });
+
+  describe('[computeStyle]' + (positionFixed ? ' Fixed' : ''), () => {
+    describe('x="top" y="left"', () => {
+      it('positions a popper on the body correctly', (done) => {
+        const reference = appendNewRef(1);
+        const popper = appendNewPopper(2);
+
+        new Popper(reference, popper, {
+          modifiers: {
+            computeStyle: {
+              x: 'top',
+              y: 'left',
+            },
+          },
+          onCreate(data) {
+            const popRect = getRect(popper);
+            const refRect = getRect(reference);
+            expect(popRect.top - arrowSize).toBeApprox(refRect.bottom);
+            expect(popRect.left).toBeApprox(5);
+            data.instance.destroy();
+            done();
+          },
+        });
+      });
+
+      it('positions a popper on a scrolled body correctly', (done) => {
+        jasmineWrapper.style.height = '500vh';
+        jasmineWrapper.style.width = '500vw';
+
+        const reference = appendNewRef(1);
+        const popper = appendNewPopper(2);
+
+        new Popper(reference, popper, {
+          modifiers: {
+            computeStyle: {
+              x: 'top',
+              y: 'left',
+            },
+          },
+          onCreate(data) {
+            const popRect = getRect(popper);
+            const refRect = getRect(reference);
+            expect(popRect.top - arrowSize).toBeApprox(refRect.bottom);
+            expect(popRect.left).toBeApprox(5);
+            jasmineWrapper.style.cssText = null;
+            data.instance.destroy();
+            done();
+          },
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
…ht` when y="left"

Fixes #585

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
