### PR TITLE
Unignore flow typings from npm publish

### DIFF
--- a/packages/popper/.npmignore
+++ b/packages/popper/.npmignore
@@ -6,3 +6,4 @@
 #======================
 !dist/**/*
 !index.d.ts
+!index.js.flow


### PR DESCRIPTION
I believe that flow typings should be published alongside typescript typings :)