### PR TITLE
feat: use visibility instead of display for tooltip

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -190,7 +190,7 @@ export default class Tooltip {
 
     // if the tooltipNode already exists, just show it
     if (this._tooltipNode) {
-      this._tooltipNode.style.display = '';
+      this._tooltipNode.style.visibility = 'visible';
       this._tooltipNode.setAttribute('aria-hidden', 'false');
       this.popperInstance.update();
       return this;
@@ -261,7 +261,7 @@ export default class Tooltip {
     this._isOpen = false;
 
     // hide tooltipNode
-    this._tooltipNode.style.display = 'none';
+    this._tooltipNode.style.visibility = 'hidden';
     this._tooltipNode.setAttribute('aria-hidden', 'true');
 
     return this;

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -45,7 +45,7 @@ describe('[tooltip.js]', () => {
       then(() => instance.hide());
 
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('hidden');
         done();
       });
     });
@@ -72,7 +72,7 @@ describe('[tooltip.js]', () => {
       then(() => instance.toggle());
 
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('hidden');
         done();
       });
     });
@@ -390,7 +390,7 @@ describe('[tooltip.js]', () => {
       reference.dispatchEvent(new CustomEvent('mouseenter'));
       then(() => reference.dispatchEvent(new CustomEvent('mouseleave')), 200);
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('hidden');
         done();
       }, 200);
     });
@@ -416,7 +416,7 @@ describe('[tooltip.js]', () => {
           .dispatchEvent(new CustomEvent('mouseleave'))
       );
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('hidden');
         done();
       }, 200);
     });
@@ -443,7 +443,7 @@ describe('[tooltip.js]', () => {
       );
       then(() => reference.dispatchEvent(new CustomEvent('mouseenter')));
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('visible');
         done();
       }, 200);
     });
@@ -493,7 +493,7 @@ describe('[tooltip.js]', () => {
       reference.dispatchEvent(new CustomEvent('click'));
       then(() => reference.dispatchEvent(new CustomEvent('click')));
       then(() => {
-        expect(document.querySelector('.tooltip').style.display).toBe('none');
+        expect(document.querySelector('.tooltip').style.visibility).toBe('hidden');
         done();
       });
     });


### PR DESCRIPTION
Visibility can be animated, but display cannot. Because the tooltips already have `position: absolute` added, ultimately, this has no bearing on the way these tooltips work other than the fact that they can be animated more easily than display. For example, the below makes the tooltip fade in and out:

```css
@keyframes fade-in {
  0% { opacity: 0; }
  100% { opacity: 1; }
}
.tooltip {
  animation: fade-in 100ms ease-in;
}
.tooltip[aria-hidden="true"] {
  transition: opacity 100ms ease-in, visibility 100s linear;
  opacity: 0;
}
.tooltip[aria-hidden="false"] {
  transition: opacity 100ms ease-in, visibility 0s linear;
  opacity: 1;
}
```

whereas using `display` prevents the `opacity` transition from happening, and the tooltip appears and disappears immediately after the first fade-in animation.

Ultimately, it would be nice to add `.show` and `.hide` classes to the tooltips to avoid using `[aria-hidden]` as a way of identifying the states, but this can be added in a future PR if desired. For now, the main goal is to make everything animateable.