### PR TITLE
_tooltipNode.parentNode may be 'body'

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -444,7 +444,7 @@ export default class Tooltip {
       }
       return;
     }
-    const titleNode = this._tooltipNode.parentNode.querySelector(this.options.innerSelector);
+    const titleNode = this._tooltipNode.querySelector(this.options.innerSelector);
     this._clearTitleContent(titleNode, this.options.html, this.reference.getAttribute('title') || this.options.title)
     this._addTitleContent(this.reference, title, this.options.html, titleNode);
     this.options.title = title;


### PR DESCRIPTION
if the tooltip was appended to `body`, `_tooltipNode.parentNode` may be `body`

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
