### PR TITLE
fix: update tooltip typings

### DIFF
--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -5,10 +5,12 @@ export type TitleFunction = () => string;
 export type Delay = Record<'show' | 'hide', number>;
 
 export interface Options {
+  placement?: Placement;
+  arrowSelector?: string;
+  innerSelector?: string;
   container?: HTMLElement | string;
   delay?: number | Delay;
   html?: boolean;
-  placement?: Placement;
   template?: string;
   title?: string | HTMLElement | TitleFunction;
   /**
@@ -17,6 +19,7 @@ export interface Options {
    * e.g. 'hover focus'
    */
   trigger?: string;
+  closeOnClickOutside?: boolean;
   boundariesElement?: Boundary | HTMLElement;
   offset?: number | string;
   popperOptions?: PopperOptions;
@@ -34,6 +37,8 @@ declare class Tooltip {
   dispose(): void;
 
   toggle(): void;
+
+  updateTitleContent(title: string | HTMLElement): void;
 }
 
 export default Tooltip;


### PR DESCRIPTION
Updated outdated typings of tooltip.js (see #643)

Can you release again to use the new features with proper typings?

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
