### PR TITLE
remove .parentNode when selecting inner tooltip, fixing selectivity p…

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -444,7 +444,7 @@ export default class Tooltip {
       }
       return;
     }
-    const titleNode = this._tooltipNode.parentNode.querySelector(this.options.innerSelector);
+    const titleNode = this._tooltipNode.querySelector(this.options.innerSelector);
     this._clearTitleContent(titleNode, this.options.html, this.reference.getAttribute('title') || this.options.title)
     this._addTitleContent(this.reference, title, this.options.html, titleNode);
     this.options.title = title;


### PR DESCRIPTION
remove .parentNode when selecting inner tooltip, fixing selectivity problem described in #676

I had 3 failing tests, but they were failing before my changes. I don't have time to look deeper into it right now, but maybe you're aware of the issue already.

```
FAILED TESTS:
  utils/getBoundaries
    × returns a boundary defined by the document element.
      HeadlessChrome 0.0.0 (Windows 10 0.0.0)
    Expected false to be truthy.
        at expectBoundary (tests/unit/getBoundaries.js:681:66)
        at UserContext.<anonymous> (tests/unit/getBoundaries.js:730:5)

    × returns a boundary defined by the document element by way of a child reference.
      HeadlessChrome 0.0.0 (Windows 10 0.0.0)
    Expected false to be truthy.
        at expectBoundary (tests/unit/getBoundaries.js:681:66)
        at UserContext.<anonymous> (tests/unit/getBoundaries.js:740:5)

    × returns a custom defined boundary within the page.
      HeadlessChrome 0.0.0 (Windows 10 0.0.0)
    Expected false to be truthy.
        at expectBoundary (tests/unit/getBoundaries.js:681:66)
        at UserContext.<anonymous> (tests/unit/getBoundaries.js:750:5)
```