### PR TITLE
Apply window methods to correct window reference of target element

### DIFF
--- a/packages/popper/src/index.js
+++ b/packages/popper/src/index.js
@@ -1,6 +1,7 @@
 // Utils
 import debounce from './utils/debounce';
 import isFunction from './utils/isFunction';
+import getWindow from './utils/getWindow';
 
 // Methods
 import update from './methods/update';
@@ -108,7 +109,7 @@ export default class Popper {
    * @method scheduleUpdate
    * @memberof Popper
    */
-  scheduleUpdate = () => requestAnimationFrame(this.update);
+  scheduleUpdate = () => getWindow(this.popper).requestAnimationFrame(this.update);
 
   /**
    * Collection of utilities useful when writing custom modifiers.

--- a/packages/popper/src/utils/getOuterSizes.js
+++ b/packages/popper/src/utils/getOuterSizes.js
@@ -1,3 +1,6 @@
+// Utils
+import getWindow from './utils/getWindow';
+
 /**
  * Get the outer sizes of the given element (offset size + margins)
  * @method
@@ -6,7 +9,7 @@
  * @returns {Object} object containing width and height properties
  */
 export default function getOuterSizes(element) {
-  const window = element.ownerDocument.defaultView;
+  const window = getWindow(element);
   const styles = window.getComputedStyle(element);
   const x = parseFloat(styles.marginTop) + parseFloat(styles.marginBottom);
   const y = parseFloat(styles.marginLeft) + parseFloat(styles.marginRight);

--- a/packages/popper/src/utils/getStyleComputedProperty.js
+++ b/packages/popper/src/utils/getStyleComputedProperty.js
@@ -1,3 +1,6 @@
+// Utils
+import getWindow from './utils/getWindow';
+
 /**
  * Get CSS computed property of the given element
  * @method
@@ -10,7 +13,7 @@ export default function getStyleComputedProperty(element, property) {
     return [];
   }
   // NOTE: 1 DOM access here
-  const window = element.ownerDocument.defaultView;
+  const window = getWindow(element);
   const css = window.getComputedStyle(element, null);
   return property ? css[property] : css;
 }


### PR DESCRIPTION
There are some places where https://github.com/FezVrasta/popper.js/pull/678 misses to update the correct context of the window object. 

