### PR TITLE
Add ember-tooltips to Popper.js mentions

### DIFF
--- a/MENTIONS.md
+++ b/MENTIONS.md
@@ -64,6 +64,10 @@ Vue.js 2.x directive
 
 An Ember-centric wrapper around Popper.js.
 
+### [ember-tooltips](https://github.com/sir-dunxalot/ember-tooltips)
+
+An Ember library for creating tooltips and popovers, built on Popper.js.
+
 ## Preact and Inferno
 
 ### [react-popper](https://github.com/souporserious/react-popper)


### PR DESCRIPTION
Updates `MENTIONS.md` to include ember-tooltips, which uses `Popper.js` in the recently-released version `3.0.0` of ember-tooltips.