### PR TITLE
Use the arrow element's parent to compute margin and border

### DIFF
--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -74,8 +74,8 @@ export default function arrow(data, options) {
   // take popper margin in account because we don't have this info available
   const popperCss = getStyleComputedProperty(data.instance.popper);
   const parentCss = getStyleComputedProperty(arrowElementParent);
-  const marginProperty = 'margin' + sideCapitalized;
-  const borderProperty = 'border' + sideCapitalized + 'Width';
+  const marginProperty = `margin${sideCapitalized}`;
+  const borderProperty = `border${sideCapitalized}Width`;
   const popperMarginSide = parseFloat(popperCss[marginProperty], 10);
   const popperBorderSide = parseFloat(popperCss[borderProperty], 10);
   const parentMarginSide = parseFloat(parentCss[marginProperty], 10);

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -36,8 +36,6 @@ export default function arrow(data, options) {
       return data;
     }
   }
-
-  const arrowElementParent = arrowElement.parentNode;
   
   const placement = data.placement.split('-')[0];
   const { popper, reference } = data.offsets;
@@ -72,7 +70,7 @@ export default function arrow(data, options) {
 
   // Compute the sideValue using the updated popper offsets
   // take popper margin in account because we don't have this info available
-  const css = getStyleComputedProperty(arrowElementParent);
+  const css = getStyleComputedProperty(arrowElement.parentNode);
   const popperMarginSide = parseFloat(css[`margin${sideCapitalized}`], 10);
   const popperBorderSide = parseFloat(css[`border${sideCapitalized}Width`], 10);
   let sideValue =

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -37,6 +37,8 @@ export default function arrow(data, options) {
     }
   }
 
+  const arrowElementParent = arrowElement.parentNode;
+  
   const placement = data.placement.split('-')[0];
   const { popper, reference } = data.offsets;
   const isVertical = ['left', 'right'].indexOf(placement) !== -1;
@@ -70,7 +72,7 @@ export default function arrow(data, options) {
 
   // Compute the sideValue using the updated popper offsets
   // take popper margin in account because we don't have this info available
-  const css = getStyleComputedProperty(data.instance.popper);
+  const css = getStyleComputedProperty(arrowElementParent);
   const popperMarginSide = parseFloat(css[`margin${sideCapitalized}`], 10);
   const popperBorderSide = parseFloat(css[`border${sideCapitalized}Width`], 10);
   let sideValue =

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -36,7 +36,7 @@ export default function arrow(data, options) {
       return data;
     }
   }
-  
+
   const placement = data.placement.split('-')[0];
   const { popper, reference } = data.offsets;
   const isVertical = ['left', 'right'].indexOf(placement) !== -1;

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -36,6 +36,8 @@ export default function arrow(data, options) {
       return data;
     }
   }
+  
+  const arrowElementParent = arrowElement.parentNode;
 
   const placement = data.placement.split('-')[0];
   const { popper, reference } = data.offsets;
@@ -70,11 +72,18 @@ export default function arrow(data, options) {
 
   // Compute the sideValue using the updated popper offsets
   // take popper margin in account because we don't have this info available
-  const css = getStyleComputedProperty(arrowElement.parentNode);
-  const popperMarginSide = parseFloat(css[`margin${sideCapitalized}`], 10);
-  const popperBorderSide = parseFloat(css[`border${sideCapitalized}Width`], 10);
+  const popperCss = getStyleComputedProperty(data.instance.popper);
+  const parentCss = getStyleComputedProperty(arrowElementParent);
+  const popperMarginSide = parseFloat(popperCss['margin' + sideCapitalized], 10);
+  const popperBorderSide = parseFloat(popperCss['border' + sideCapitalized + 'Width'], 10);
+  const parentMarginSide = parseFloat(parentCss['margin' + sideCapitalized], 10);
+  const parentBorderSide = parseFloat(parentCss['border' + sideCapitalized + 'Width'], 10);
+  const parentOffset =
+    arrowElementParent !== data.instance.popper
+      ? parentMarginSide - parentBorderSide
+      : 0;
   let sideValue =
-    center - data.offsets.popper[side] - popperMarginSide - popperBorderSide;
+    center - data.offsets.popper[side] - popperMarginSide - popperBorderSide - parentOffset;
 
   // prevent arrowElement from being placed not contiguously to its popper
   sideValue = Math.max(Math.min(popper[len] - arrowElementSize, sideValue), 0);

--- a/packages/popper/src/modifiers/arrow.js
+++ b/packages/popper/src/modifiers/arrow.js
@@ -36,7 +36,7 @@ export default function arrow(data, options) {
       return data;
     }
   }
-  
+
   const arrowElementParent = arrowElement.parentNode;
 
   const placement = data.placement.split('-')[0];
@@ -74,16 +74,22 @@ export default function arrow(data, options) {
   // take popper margin in account because we don't have this info available
   const popperCss = getStyleComputedProperty(data.instance.popper);
   const parentCss = getStyleComputedProperty(arrowElementParent);
-  const popperMarginSide = parseFloat(popperCss['margin' + sideCapitalized], 10);
-  const popperBorderSide = parseFloat(popperCss['border' + sideCapitalized + 'Width'], 10);
-  const parentMarginSide = parseFloat(parentCss['margin' + sideCapitalized], 10);
-  const parentBorderSide = parseFloat(parentCss['border' + sideCapitalized + 'Width'], 10);
+  const marginProperty = 'margin' + sideCapitalized;
+  const borderProperty = 'border' + sideCapitalized + 'Width';
+  const popperMarginSide = parseFloat(popperCss[marginProperty], 10);
+  const popperBorderSide = parseFloat(popperCss[borderProperty], 10);
+  const parentMarginSide = parseFloat(parentCss[marginProperty], 10);
+  const parentBorderSide = parseFloat(parentCss[borderProperty], 10);
   const parentOffset =
     arrowElementParent !== data.instance.popper
       ? parentMarginSide - parentBorderSide
       : 0;
   let sideValue =
-    center - data.offsets.popper[side] - popperMarginSide - popperBorderSide - parentOffset;
+    center -
+    data.offsets.popper[side] -
+    popperMarginSide -
+    popperBorderSide +
+    parentOffset;
 
   // prevent arrowElement from being placed not contiguously to its popper
   sideValue = Math.max(Math.min(popper[len] - arrowElementSize, sideValue), 0);


### PR DESCRIPTION
Fixes #710 

Can't seem to run the tests.

New: https://codepen.io/anon/pen/yQXRaG (line 1412)
Old: https://codepen.io/anon/pen/dQpGdm (v1.14.5)

I'm kind of worried about this assumption as a change to the behavior but it seems necessary to fix the problem mentioned in the issue