### PR TITLE
Improve rounding

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -38,13 +38,20 @@ export default function computeStyle(data, options) {
   };
 
   // Avoid blurry text by using full pixel integers.
-  // For pixel-perfect positioning, top/bottom prefers rounded
-  // values, while left/right prefers floored values.
+  // For pixel-perfect positioning in horizontal placements, top/bottom prefers
+  // rounded values, while left/right prefers floored values.
+  // Always use `round` for variations (-start and -end).
+  const placement = data.placement.split('-')[0];
+  const toInteger =
+    ['left', 'right'].indexOf(placement) !== -1 ||
+    data.placement.indexOf('-') > -1
+      ? Math.round
+      : Math.floor;
   const offsets = {
-    left: Math.floor(popper.left),
+    left: toInteger(popper.left),
     top: Math.round(popper.top),
     bottom: Math.round(popper.bottom),
-    right: Math.floor(popper.right),
+    right: toInteger(popper.right),
   };
 
   const sideA = x === 'bottom' ? 'top' : 'bottom';


### PR DESCRIPTION
Fixes #713 

It appears that `Math.round()` is always preferred except with placements `top` and `bottom` (not a variation) and where `Math.floor()` is preferred (and only on the `left` and `right` values)...

See the playground: https://codepen.io/anon/pen/Pxjdoo
