### PR TITLE
allow TitleFunction to return a DomNode or DocumentFragment 

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -169,11 +169,9 @@ export default class Tooltip {
       // if title is a element node or document fragment, append it only if allowHtml is true
       allowHtml && titleNode.appendChild(title);
     } else if (isFunction(title)) {
-      // if title is a function, call it and set textContent or innerHtml depending by `allowHtml` value
-      const titleText = title.call(reference);
-      allowHtml
-        ? (titleNode.innerHTML = titleText)
-        : (titleNode.textContent = titleText);
+      // Recursively call ourself so that the return value of the function gets handled appropriately - either
+      // as a dom node, a string, or even as another function.
+      this._addTitleContent(reference, title.call(reference), allowHtml, titleNode);
     } else {
       // if it's just a simple text, set textContent or innerHtml depending by `allowHtml` value
       allowHtml ? (titleNode.innerHTML = title) : (titleNode.textContent = title);

--- a/packages/tooltip/tests/functional/tooltip.js
+++ b/packages/tooltip/tests/functional/tooltip.js
@@ -249,7 +249,7 @@ describe('[tooltip.js]', () => {
       });
     });
 
-    it('should use a function result as tooltip content', done => {
+    it('should use a string returned by a function as tooltip content', done => {
       instance = new Tooltip(reference, {
         title: () => 'foobar',
       });
@@ -260,6 +260,62 @@ describe('[tooltip.js]', () => {
         expect(
           document.querySelector('.tooltip .tooltip-inner').textContent
         ).toBe('foobar');
+        done();
+      });
+    });
+
+    it('should use a DOM node returned by a function as tooltip content', done => {
+      const content = document.createElement('div');
+      content.textContent = 'foobar';
+      instance = new Tooltip(reference, {
+        title: () => content,
+        html: true,
+      });
+
+      instance.show();
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip .tooltip-inner').innerHTML
+        ).toBe('<div>foobar</div>');
+        done();
+      });
+    });
+
+    it('should use a document fragment returned by a function as tooltip content', done => {
+      const content = document.createDocumentFragment();
+      const inner = document.createElement('div');
+      inner.textContent = 'test';
+      content.appendChild(inner);
+      instance = new Tooltip(reference, {
+        title: () => content,
+        html: true,
+      });
+
+      instance.show();
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip .tooltip-inner').innerHTML
+        ).toBe('<div>test</div>');
+        done();
+      });
+    });
+
+    it('should not use dom node returned by function as tooltip content if html option disabled', done => {
+      const content = document.createElement('div');
+      content.textContent = 'test';
+      instance = new Tooltip(reference, {
+        title: () => content,
+        html: false,
+      });
+
+      instance.show();
+
+      then(() => {
+        expect(
+          document.querySelector('.tooltip .tooltip-inner').innerHTML
+        ).toBe('');
         done();
       });
     });


### PR DESCRIPTION
Tooltip.js allows the title to be provided via:
1) string
2) dom node
3) function

If a dom node is provided, it is accepted so long as the `allow html` option is enabled. However, currently, the function can only return a string. I think the function should also be allowed to return a dom node / frag, so long as the `allow html` flag is enabled.

It would be consistent, and useful, so I made a patch.

