### PR TITLE
fix: isFixed with detached DOM element

### DIFF
--- a/packages/popper/src/utils/isFixed.js
+++ b/packages/popper/src/utils/isFixed.js
@@ -17,5 +17,9 @@ export default function isFixed(element) {
   if (getStyleComputedProperty(element, 'position') === 'fixed') {
     return true;
   }
-  return isFixed(getParentNode(element));
+  const parentNode = getParentNode(element);
+  if (!parentNode) {
+    return false;
+  }
+  return isFixed(parentNode);
 }

--- a/packages/popper/tests/unit/isFixed.js
+++ b/packages/popper/tests/unit/isFixed.js
@@ -42,4 +42,9 @@ describe('utils/isFixed', () => {
       expect(isFixed(node)).to.be.false;
     });
   });
+
+  it('element is detached from the DOM', () => {
+    const node = document.createElement('div');
+    expect(isFixed(node)).to.be.false;
+  });
 });


### PR DESCRIPTION
Hi there,

We use popper.js with Vue.js, and we noticed that it generates a lot of errors noise when a DOM element gets detached and the `preventOverflow` is called: `isFixed` tries to go up the DOM tree and tries to resolve a `nodeName` of an undefined parent.

So here is a fix for the isFixed util to avoid crashing on detached DOM elements (this works perfectly with this patch).

Thanks!