### PR TITLE
Fix TS: padding types of `flip` and `preventOverflow` #518

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -40,6 +40,13 @@ declare namespace Popper {
     'x-placement': Placement;
   }
 
+  export interface Padding {
+    top: number,
+    bottom: number,
+    left: number,
+    right: number,
+  }
+
   export interface BaseModifier {
     order?: number;
     enabled?: boolean;
@@ -53,7 +60,7 @@ declare namespace Popper {
     };
     preventOverflow?: BaseModifier & {
       priority?: Position[],
-      padding?: number,
+      padding?: number | Padding,
       boundariesElement?: Boundary | Element,
       escapeWithReference?: boolean
     };
@@ -63,7 +70,7 @@ declare namespace Popper {
     };
     flip?: BaseModifier & {
       behavior?: Behavior | Position[],
-      padding?: number,
+      padding?: number | Padding,
       boundariesElement?: Boundary | Element,
     };
     inner?: BaseModifier;

--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -41,10 +41,10 @@ declare namespace Popper {
   }
 
   export interface Padding {
-    top: number,
-    bottom: number,
-    left: number,
-    right: number,
+    top?: number,
+    bottom?: number,
+    left?: number,
+    right?: number,
   }
 
   export interface BaseModifier {

--- a/packages/popper/index.js.flow
+++ b/packages/popper/index.js.flow
@@ -51,6 +51,13 @@ declare module 'popper.js' {
 
   declare type ModifierFn = (data: Data, options: Object) => Data;
 
+  declare type Padding = {
+    top?: number,
+    bottom?: number,
+    left?: number,
+    right?: number,
+  }
+
   declare type BaseModifier = {
     order?: number,
     enabled?: boolean,
@@ -64,7 +71,7 @@ declare module 'popper.js' {
     },
     preventOverflow?: BaseModifier & {
       priority?: Position[],
-      padding?: number,
+      padding?: number | Padding,
       boundariesElement?: Boundary | Element,
       escapeWithReference?: boolean,
     },
@@ -74,7 +81,7 @@ declare module 'popper.js' {
     },
     flip?: BaseModifier & {
       behavior?: Behavior | Position[],
-      padding?: number,
+      padding?: number | Padding,
       boundariesElement?: Boundary | Element,
     },
     inner?: BaseModifier,


### PR DESCRIPTION
Added types of padding, that are missing since #615 PR. 