### PR TITLE
Add "unpkg" field to package.json to link to minified version

### DIFF
--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -26,6 +26,7 @@
   ],
   "main": "dist/umd/popper.js",
   "module": "dist/esm/popper.js",
+  "unpkg": "dist/umd/popper.min.js",
   "types": "index.d.ts",
   "scripts": {
     "prepare": "yarn build",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "./dist/umd/tooltip.js",
   "module": "./dist/esm/tooltip.js",
+  "unpkg": "./dist/umd/tooltip.min.js",
   "types": "index.d.ts",
   "scripts": {
     "build": "node bundle.js",


### PR DESCRIPTION
On the Tippy.js website under [CDN](https://atomiks.github.io/tippyjs/getting-started/#option-1-cdn), it would be nice to have consistent formats