### PR TITLE
Fix(types): add missing `reference` and `popper` class properties

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -158,8 +158,8 @@ declare class Popper {
   static Defaults: PopperOptions;
 
   options: PopperOptions;
-  popper: HTMLElement;
-  reference: HTMLElement;
+  popper: Element;
+  reference: Element | ReferenceObject;
 
   constructor(reference: Element | ReferenceObject, popper: Element, options?: PopperOptions);
 

--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -158,6 +158,8 @@ declare class Popper {
   static Defaults: PopperOptions;
 
   options: PopperOptions;
+  popper: HTMLElement;
+  reference: HTMLElement;
 
   constructor(reference: Element | ReferenceObject, popper: Element, options?: PopperOptions);
 

--- a/packages/popper/index.js.flow
+++ b/packages/popper/index.js.flow
@@ -142,6 +142,9 @@ declare module 'popper.js' {
   declare class Popper {
     static placements: Placement;
 
+    popper: Element;
+    reference: Element | ReferenceObject;
+
     constructor(
       reference: Element | ReferenceObject,
       popper: Element,

--- a/packages/popper/src/index.js
+++ b/packages/popper/src/index.js
@@ -14,8 +14,8 @@ export default class Popper {
   /**
    * Creates a new Popper.js instance.
    * @class Popper
-   * @param {HTMLElement|referenceObject} reference - The reference element used to position the popper
-   * @param {HTMLElement} popper - The HTML element used as the popper
+   * @param {Element|referenceObject} reference - The reference element used to position the popper
+   * @param {Element} popper - The HTML / XML element used as the popper
    * @param {Object} options - Your custom options to override the ones defined in [Defaults](#defaults)
    * @return {Object} instance - The generated Popper.js instance
    */


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->

Reference: https://github.com/FezVrasta/popper.js/blob/bd1faa9a27499433443bb4c42b3dea9ecf055777/packages/popper/src/index.js#L37-L38