### PR TITLE
Remove /src from .npmignore (for debugging)

### DIFF
--- a/packages/popper/.npmignore
+++ b/packages/popper/.npmignore
@@ -7,3 +7,4 @@
 !dist/**/*
 !index.d.ts
 !index.js.flow
+!src/**


### PR DESCRIPTION
Popper publishes source maps to NPM (great!) but it doesn't publish the `/src` folder that the sourcemaps point to. This makes it harder to debug into & set breakpoints in popper code from Chrome or an IDE like VSCode.  This PR updates .npmignore to ensure that the `/src` folder is also (along with `/dist`) published to NPM.

This shouldn't change anything about Popper's runtime user-facing behavior and the tests probably operate on the source (not a package downloaded from NPM), so I wasn't sure how to build a test to validate these changes. Let me know if you think that new tests are needed. 

Fixes #785.

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
