### PR TITLE
Use translate instead of translate3d

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -50,7 +50,7 @@ export default function computeStyle(data, options) {
   const sideB = y === 'right' ? 'left' : 'right';
 
   // if gpuAcceleration is set to `true` and transform is supported,
-  //  we use `translate3d` to apply the position to the popper we
+  //  we use `translate` to apply the position to the popper we
   // automatically use the supported prefixed version if needed
   const prefixedProperty = getSupportedPropertyName('transform');
 
@@ -85,7 +85,7 @@ export default function computeStyle(data, options) {
     left = offsets.left;
   }
   if (gpuAcceleration && prefixedProperty) {
-    styles[prefixedProperty] = `translate3d(${left}px, ${top}px, 0)`;
+    styles[prefixedProperty] = `translate(${left}px, ${top}px)`;
     styles[sideA] = 0;
     styles[sideB] = 0;
     styles.willChange = 'transform';

--- a/packages/popper/tests/functional/lifecycle.js
+++ b/packages/popper/tests/functional/lifecycle.js
@@ -111,7 +111,7 @@ import '@popperjs/test-utils/setup';
         right: '100px',
         bottom: '100px',
         position: 'absolute',
-        transform: 'translate3d(100px, 100px, 0)',
+        transform: 'translate(100px, 100px)',
         willChange: 'transform',
       }
 

--- a/packages/popper/tests/unit/getBoundaries.js
+++ b/packages/popper/tests/unit/getBoundaries.js
@@ -49,7 +49,7 @@ describe('utils/getBoundaries', () => {
       height: '350px',
       width: '625px',
       position: 'absolute',
-      transform: 'translate3d(100px, 100px, 0)',
+      transform: 'translate(100px, 100px)',
       willChange: 'transform',
     });
 


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->

In some browsers like Chrome, using `translate3d(x, y, 0)` results in blurry text, while `translate(x, y)` doesn't.