### PR TITLE
Update isBrowser.js - check if navigator is available

### DIFF
--- a/packages/popper/src/utils/isBrowser.js
+++ b/packages/popper/src/utils/isBrowser.js
@@ -1,1 +1,1 @@
-export default typeof window !== 'undefined' && typeof document !== 'undefined';
+export default typeof window !== 'undefined' && typeof document !== 'undefined' && typeof navigator !== 'undefined';


### PR DESCRIPTION
Some implementations of server-side rendering support `window` and `document` objects but `navigator` could be undefined. To prevent error-prone behavior we should check the existence of `navigator` object in global scope.