### PR TITLE
fix: ESM style export of Padding in TS typedefs

### DIFF
--- a/packages/popper/index.d.ts
+++ b/packages/popper/index.d.ts
@@ -140,6 +140,7 @@ declare namespace Popper {
 
 // Re-export types in the Popper namespace so that they can be accessed as top-level named exports.
 // These re-exports should be removed in 2.x when the "declare namespace Popper" syntax is removed.
+export type Padding = Popper.Padding;
 export type Position = Popper.Position;
 export type Placement = Popper.Placement;
 export type Boundary = Popper.Boundary;


### PR DESCRIPTION
TypeScript definitions only declared `Padding` as available via a namespace, rather than ESM style exports. This is a one-liner to fix that.