### PR TITLE
Fix `.js.flow` definitions

### DIFF
--- a/packages/popper/index.js.flow
+++ b/packages/popper/index.js.flow
@@ -1,157 +1,156 @@
-declare module 'popper.js' {
-  declare type Position = 'top' | 'right' | 'bottom' | 'left';
-  declare type Placement =
-    | 'auto-start'
-    | 'auto'
-    | 'auto-end'
-    | 'top-start'
-    | 'top'
-    | 'top-end'
-    | 'right-start'
-    | 'right'
-    | 'right-end'
-    | 'bottom-end'
-    | 'bottom'
-    | 'bottom-start'
-    | 'left-end'
-    | 'left'
-    | 'left-start';
+// @flow
 
-  declare type Offset = {
-    top: number,
-    left: number,
-    width: number,
-    height: number,
-    position: Position,
-  };
+export type Position = 'top' | 'right' | 'bottom' | 'left';
 
-  declare type Boundary = 'scrollParent' | 'viewport' | 'window';
+export type Placement =
+  | 'auto-start'
+  | 'auto'
+  | 'auto-end'
+  | 'top-start'
+  | 'top'
+  | 'top-end'
+  | 'right-start'
+  | 'right'
+  | 'right-end'
+  | 'bottom-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'left-end'
+  | 'left'
+  | 'left-start';
 
-  declare type Behavior = 'flip' | 'clockwise' | 'counterclockwise';
+export type Offset = {
+  top: number,
+  left: number,
+  width: number,
+  height: number,
+  position: Position,
+};
 
-  declare type Data = {
-    instance: Popper,
-    placement: Placement,
-    originalPlacement: Placement,
-    flipped: boolean,
-    hide: boolean,
-    arrowElement: Element,
-    styles: CSSStyleDeclaration,
-    arrowStyles: CSSStyleDeclaration,
-    boundaries: Object,
-    offsets: {
-      popper: Offset,
-      reference: Offset,
-      arrow: {
+export type Boundary = 'scrollParent' | 'viewport' | 'window';
+
+export type Behavior = 'flip' | 'clockwise' | 'counterclockwise';
+
+export type Data = {
+  instance: Popper,
+  placement: Placement,
+  originalPlacement: Placement,
+  flipped: boolean,
+  hide: boolean,
+  arrowElement: Element,
+  styles: CSSStyleDeclaration,
+  arrowStyles: CSSStyleDeclaration,
+  boundaries: Object,
+  offsets: {
+    popper: Offset,
+    reference: Offset,
+    arrow: {
+      top: number,
+      left: number,
+    },
+  },
+};
+
+export type ModifierFn = (data: Data, options: Object) => Data;
+
+export type Padding = {
+  top?: number,
+  bottom?: number,
+  left?: number,
+  right?: number,
+};
+
+export type BaseModifier = {
+  order?: number,
+  enabled?: boolean,
+  fn?: ModifierFn,
+};
+
+export type Modifiers = {
+  shift?: BaseModifier,
+  offset?: BaseModifier & {
+    offset?: number | string,
+  },
+  preventOverflow?: BaseModifier & {
+    priority?: Position[],
+    padding?: number | Padding,
+    boundariesElement?: Boundary | Element,
+    escapeWithReference?: boolean,
+  },
+  keepTogether?: BaseModifier,
+  arrow?: BaseModifier & {
+    element?: string | Element | null,
+  },
+  flip?: BaseModifier & {
+    behavior?: Behavior | Position[],
+    padding?: number | Padding,
+    boundariesElement?: Boundary | Element,
+    flipVariations?: boolean,
+    flipVariationsByContent?: boolean,
+  },
+  inner?: BaseModifier,
+  hide?: BaseModifier,
+  applyStyle?: BaseModifier & {
+    onLoad?: Function,
+    gpuAcceleration?: boolean,
+  },
+  computeStyle?: BaseModifier & {
+    gpuAcceleration?: boolean,
+    x?: 'bottom' | 'top',
+    y?: 'left' | 'right',
+  },
+
+  [name: string]: (BaseModifier & { [string]: * }) | null,
+};
+
+export type Options = {
+  placement?: Placement,
+  positionFixed?: boolean,
+  eventsEnabled?: boolean,
+  modifiers?: Modifiers,
+  removeOnDestroy?: boolean,
+
+  onCreate?: (data: Data) => void,
+
+  onUpdate?: (data: Data) => void,
+};
+
+export type ReferenceObject = {
+  +clientHeight: number,
+  +clientWidth: number,
+  +referenceNode?: Node,
+
+  getBoundingClientRect():
+    | ClientRect
+    | {
+        width: number,
+        height: number,
         top: number,
+        right: number,
+        bottom: number,
         left: number,
       },
-    },
-  };
+};
 
-  declare type ModifierFn = (data: Data, options: Object) => Data;
+export type Instance = {
+  destroy: () => void,
+  scheduleUpdate: () => void,
+  update: () => void,
+  enableEventListeners: () => void,
+  disableEventListeners: () => void,
+};
 
-  declare type Padding = {
-    top?: number,
-    bottom?: number,
-    left?: number,
-    right?: number,
-  }
+declare class Popper {
+  static placements: Placement;
 
-  declare type BaseModifier = {
-    order?: number,
-    enabled?: boolean,
-    fn?: ModifierFn,
-  };
+  popper: Element;
+  reference: Element | ReferenceObject;
 
-  declare type Modifiers = {
-    shift?: BaseModifier,
-    offset?: BaseModifier & {
-      offset?: number | string,
-    },
-    preventOverflow?: BaseModifier & {
-      priority?: Position[],
-      padding?: number | Padding,
-      boundariesElement?: Boundary | Element,
-      escapeWithReference?: boolean,
-    },
-    keepTogether?: BaseModifier,
-    arrow?: BaseModifier & {
-      element?: string | Element | null,
-    },
-    flip?: BaseModifier & {
-      behavior?: Behavior | Position[],
-      padding?: number | Padding,
-      boundariesElement?: Boundary | Element,
-      flipVariations?: boolean,
-      flipVariationsByContent?: boolean,
-    },
-    inner?: BaseModifier,
-    hide?: BaseModifier,
-    applyStyle?: BaseModifier & {
-      onLoad?: Function,
-      gpuAcceleration?: boolean,
-    },
-    computeStyle?: BaseModifier & {
-      gpuAcceleration?: boolean,
-      x?: 'bottom' | 'top',
-      y?: 'left' | 'right',
-    },
-
-    [name: string]: (BaseModifier & { [string]: * }) | null,
-  };
-
-  declare type Options = {
-    placement?: Placement,
-    positionFixed?: boolean,
-    eventsEnabled?: boolean,
-    modifiers?: Modifiers,
-    removeOnDestroy?: boolean,
-
-    onCreate?: (data: Data) => void,
-
-    onUpdate?: (data: Data) => void,
-  };
-
-  declare var placements: Placement;
-
-  declare type ReferenceObject = {
-    +clientHeight: number,
-    +clientWidth: number,
-    +referenceNode?: Node,
-
-    getBoundingClientRect():
-      | ClientRect
-      | {
-          width: number,
-          height: number,
-          top: number,
-          right: number,
-          bottom: number,
-          left: number,
-        },
-  };
-
-  declare type Instance = {
-    destroy: () => void,
-    scheduleUpdate: () => void,
-    update: () => void,
-    enableEventListeners: () => void,
-    disableEventListeners: () => void,
-  };
-
-  declare class Popper {
-    static placements: Placement;
-
-    popper: Element;
-    reference: Element | ReferenceObject;
-
-    constructor(
-      reference: Element | ReferenceObject,
-      popper: Element,
-      options?: Options
-    ): Instance;
-  }
-
-  declare module.exports: Class<Popper>;
+  constructor(
+    reference: Element | ReferenceObject,
+    popper: Element,
+    options?: Options
+  ): Instance;
 }
+
+declare export default typeof Popper;

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -33,7 +33,7 @@
     "postpublish": "nuget-publish && ./bower-publish.sh",
     "prebuild": "yarn lint",
     "pretest": "yarn lint",
-    "build": "node bundle.js && cp index.js.flow dist/umd/poppper.js.flow",
+    "build": "node bundle.js && cp index.js.flow dist/umd/popper.js.flow",
     "lint": "eslint .",
     "test": "popper-karma",
     "posttest": "tsc --project tests/types/tsconfig.json",


### PR DESCRIPTION
Hi,

in the current state of affairs, the `umd/popper.js.flow` definitions shipped alongside the `umd/popper.js` (package main entry) just doesn't work. It all resolves to `any`.

That's why you have to do [this sort of thing](https://github.com/FezVrasta/react-popper/blob/fa1b2956255666244ae102ae62f97d521f42a0a7/.flowconfig#L9) which should not be necessary. 

Causes:
1. There's a typo in the file name :) (this PR fixes it)
2. `.js.flow` declaration files have a different behaviour and syntax than "library definitions".
- They need a `// @flow` pragma
- They can't use the `declare modules` wrapper
- Types needs to be exported `export type ...`

So I managed to make this file work locally by applying all the points above, but I'm not sure how would you like to integrate it in the build workflow here. Because it makes this file significantly different from the `index.js.flow` at the package root. So waiting for feedback before pushing something.

My advice would be, don't maintain two files. Either only include the `popper.js.flow` (modified file).
Or move the library definition to `flow-typed`.  



