### PR TITLE
Declared packages side effect free and fixed existing side effects

### DIFF
--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -28,6 +28,7 @@
   "module": "dist/esm/popper.js",
   "unpkg": "dist/umd/popper.min.js",
   "types": "index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "prepare": "yarn build",
     "postpublish": "nuget-publish && ./bower-publish.sh",

--- a/packages/popper/src/utils/debounce.js
+++ b/packages/popper/src/utils/debounce.js
@@ -1,13 +1,14 @@
 import isBrowser from './isBrowser';
 
-const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
-let timeoutDuration = 0;
-for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {
-  if (isBrowser && navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
-    timeoutDuration = 1;
-    break;
+const timeoutDuration = (function(){
+  const longerTimeoutBrowsers = ['Edge', 'Trident', 'Firefox'];
+  for (let i = 0; i < longerTimeoutBrowsers.length; i += 1) {
+    if (isBrowser && navigator.userAgent.indexOf(longerTimeoutBrowsers[i]) >= 0) {
+      return 1;
+    }
   }
-}
+  return 0;
+}());
 
 export function microtaskDebounce(fn) {
   let called = false

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -7,6 +7,7 @@
   "module": "./dist/esm/tooltip.js",
   "unpkg": "./dist/umd/tooltip.min.js",
   "types": "index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build": "node bundle.js",
     "prepublish": "yarn build",


### PR DESCRIPTION
This sets the package.json field sideEffects to false. This allows for better tree shaking by downstream consumers, see https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free for more information.

I skimmed over all included files and I did not see anything that would count following webpack's definition of tree shaking other than the line in `debounce.js` I fixed.
