### PR TITLE
feat: implement DEV-only messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "popper.js",
   "version": "2.0.0-next.4",
-  "main": "dist/cjs/index.js",
-  "main:umd": "dist/umd/index.js",
+  "main": "dist/cjs/popper.js",
+  "main:umd": "dist/umd/popper.js",
   "module": "lib/index.js",
   "author": "Federico Zivolo <fzivolo@quid.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "/dist",
     "/lib"
   ],
+  "sideEffects": false,
   "prettier": {
     "semi": true,
     "trailingComma": "es5",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ const createUmdBundle = ({ minify } = {}) => ({
   },
 });
 
-const esBundle = {
+const esmBundle = {
   input: 'src/index.js',
   plugins: [
     babel(),
@@ -35,8 +35,8 @@ const esBundle = {
   ].filter(Boolean),
   output: {
     name: 'Popper',
-    file: `${dir}/es/index.js`,
-    format: 'es',
+    file: `${dir}/esm/index.js`,
+    format: 'esm',
     sourcemap: true,
   },
 };
@@ -67,14 +67,19 @@ const devBundle = {
   ],
   output: {
     name: 'Popper',
-    file: `${dir}/es/index.js`,
-    format: 'es',
+    file: `${dir}/esm/index.js`,
+    format: 'esm',
     sourcemap: true,
   },
 };
 
 const builds = IS_DEV
   ? [devBundle]
-  : [createUmdBundle(), createUmdBundle({ minify: true }), esBundle, cjsBundle];
+  : [
+      createUmdBundle(),
+      createUmdBundle({ minify: true }),
+      esmBundle,
+      cjsBundle,
+    ];
 
 export default builds;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,9 +11,7 @@ const umdBundle = minify => ({
   plugins: [
     babel(),
     replace({
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || 'development'
-      ),
+      __DEV__: "process.env.NODE_ENV !== 'production'",
     }),
     minify && terser(),
     bundleSize(),
@@ -31,9 +29,7 @@ const esBundle = minify => ({
   plugins: [
     babel(),
     replace({
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || 'development'
-      ),
+      __DEV__: "process.env.NODE_ENV !== 'production'",
     }),
     minify && terser(),
     bundleSize(),
@@ -51,9 +47,7 @@ const cjsBundle = minify => ({
   plugins: [
     babel(),
     replace({
-      'process.env.NODE_ENV': JSON.stringify(
-        process.env.NODE_ENV || 'development'
-      ),
+      __DEV__: "process.env.NODE_ENV !== 'production'",
     }),
     minify && terser(),
     bundleSize(),
@@ -65,8 +59,24 @@ const cjsBundle = minify => ({
   },
 });
 
+const devBundle = () => ({
+  input: 'src/index.js',
+  plugins: [
+    babel(),
+    replace({
+      __DEV__: 'true',
+    }),
+  ],
+  output: {
+    name: 'Popper',
+    file: `${dir}/es/index.js`,
+    format: 'es',
+    sourcemap: true,
+  },
+});
+
 const builds = IS_DEV
-  ? [esBundle()]
+  ? [devBundle()]
   : [
       umdBundle(),
       umdBundle(true),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,7 @@ const createUmdBundle = ({ minify } = {}) => ({
   ].filter(Boolean),
   output: {
     name: 'Popper',
-    file: `${dir}/umd/index${minify ? '.min' : ''}.js`,
+    file: `${dir}/umd/popper${minify ? '.min' : ''}.js`,
     format: 'umd',
     sourcemap: true,
   },
@@ -35,7 +35,7 @@ const esmBundle = {
   ].filter(Boolean),
   output: {
     name: 'Popper',
-    file: `${dir}/esm/index.js`,
+    file: `${dir}/esm/popper.js`,
     format: 'esm',
     sourcemap: true,
   },
@@ -51,7 +51,7 @@ const cjsBundle = {
     bundleSize(),
   ].filter(Boolean),
   output: {
-    file: `${dir}/cjs/index.js`,
+    file: `${dir}/cjs/popper.js`,
     format: 'cjs',
     sourcemap: true,
   },
@@ -67,7 +67,7 @@ const devBundle = {
   ],
   output: {
     name: 'Popper',
-    file: `${dir}/esm/index.js`,
+    file: `${dir}/esm/popper.js`,
     format: 'esm',
     sourcemap: true,
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,12 +6,12 @@ import { terser } from 'rollup-plugin-terser';
 const IS_DEV = process.env.NODE_ENV === 'development';
 const dir = IS_DEV ? 'tests/visual/dist' : 'dist';
 
-const umdBundle = minify => ({
+const createUmdBundle = ({ minify } = {}) => ({
   input: 'src/index.js',
   plugins: [
     babel(),
     replace({
-      __DEV__: "process.env.NODE_ENV !== 'production'",
+      __DEV__: minify ? 'false' : 'true',
     }),
     minify && terser(),
     bundleSize(),
@@ -24,42 +24,40 @@ const umdBundle = minify => ({
   },
 });
 
-const esBundle = minify => ({
+const esBundle = {
   input: 'src/index.js',
   plugins: [
     babel(),
     replace({
       __DEV__: "process.env.NODE_ENV !== 'production'",
     }),
-    minify && terser(),
     bundleSize(),
   ].filter(Boolean),
   output: {
     name: 'Popper',
-    file: `${dir}/es/index${minify ? '.min' : ''}.js`,
+    file: `${dir}/es/index.js`,
     format: 'es',
     sourcemap: true,
   },
-});
+};
 
-const cjsBundle = minify => ({
+const cjsBundle = {
   input: 'src/index.js',
   plugins: [
     babel(),
     replace({
       __DEV__: "process.env.NODE_ENV !== 'production'",
     }),
-    minify && terser(),
     bundleSize(),
   ].filter(Boolean),
   output: {
-    file: `${dir}/cjs/index${minify ? '.min' : ''}.js`,
+    file: `${dir}/cjs/index.js`,
     format: 'cjs',
     sourcemap: true,
   },
-});
+};
 
-const devBundle = () => ({
+const devBundle = {
   input: 'src/index.js',
   plugins: [
     babel(),
@@ -73,17 +71,10 @@ const devBundle = () => ({
     format: 'es',
     sourcemap: true,
   },
-});
+};
 
 const builds = IS_DEV
-  ? [devBundle()]
-  : [
-      umdBundle(),
-      umdBundle(true),
-      esBundle(),
-      esBundle(true),
-      cjsBundle(),
-      cjsBundle(true),
-    ];
+  ? [devBundle]
+  : [createUmdBundle(), createUmdBundle({ minify: true }), esBundle, cjsBundle];
 
 export default builds;

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ export default class Popper {
 
     // Validate the provided modifiers so that the consumer will get warned
     // of one of the custom modifiers is invalid for any reason
-    if (process.env.NODE_ENV !== 'production') {
+    if (__DEV__) {
       validateModifiers(this.state.options.modifiers);
     }
 


### PR DESCRIPTION
You already had `process.env.NODE_ENV` check, but I had to refactor it so it'll work for consumers (and replaced with easy `__DEV__` variable). 

I also added `"sideEffects": false` as I'm not sure if DCE for these branches works without it (it needed to be added anyway).

Resolves #841 